### PR TITLE
Hotfix/brosersync override

### DIFF
--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -70,7 +70,7 @@ function getConfig(projectDir, proxyUrl, projectPathConfig, assetsPathConfig, ou
 }
 
 /**
- * Check if user config is added and it is used.s
+ * Check if user config is added and it is used
  *
  * @param {object} config Config object to check.
  * @param {string} key Config object key to test if is false.
@@ -78,7 +78,7 @@ function getConfig(projectDir, proxyUrl, projectPathConfig, assetsPathConfig, ou
  * @since 2.0.0
  */
 function isUsed(config, key) {
-  if (config.hasOwnProperty(key) && config[key]) {
+  if (config.hasOwnProperty(key) || config[key]) {
     return false;
   }
 

--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -78,7 +78,7 @@ function getConfig(projectDir, proxyUrl, projectPathConfig, assetsPathConfig, ou
  * @since 2.0.0
  */
 function isUsed(config, key) {
-  if (config.hasOwnProperty(key) || config[key]) {
+  if (config.hasOwnProperty(key)) {
     return false;
   }
 


### PR DESCRIPTION
If value of key was false, browserSync would not be overridden, if we would like add possibility for value to be false, we should only check if key is present