### PR TITLE
Fixing CleanWebpackPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
 ## [Unreleased]
+## Changed
+- Complete rewrite of setup script for boilerplate
+- Updating CleanWebpackPlugin option to fix removing items in watch mode
+- Updating readme and docs
 
 ## [3.0.2] - 2019-12-19
 

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -20,7 +20,9 @@ module.exports = (options) => {
 
   // Clean public files before next build.
   if (isUsed(options.overrides, 'cleanWebpackPlugin')) {
-    plugins.push(new CleanWebpackPlugin());
+    plugins.push(new CleanWebpackPlugin({
+      cleanStaleWebpackAssets: false,
+    }));
   }
 
   // Provide global variables to window object.


### PR DESCRIPTION
adding cleanStaleWebpackAssets to CleanWebpackPlugin in webpack to fix removal of files being added by CopyWebpackPlugin in watch mode