### PR TITLE
change small size text on paragraph options

### DIFF
--- a/blocks/init/components/paragraph/components/paragraph-options.js
+++ b/blocks/init/components/paragraph/components/paragraph-options.js
@@ -45,7 +45,7 @@ export const ParagraphOptions = (props) => {
               value={styleSize}
               options={[
                 { label: __('Default (22px)', 'eightshift-boilerplate'), value: 'default' },
-                { label: __('Small (20px)', 'eightshift-boilerplate'), value: 'small' },
+                { label: __('Small (18px)', 'eightshift-boilerplate'), value: 'small' },
               ]}
               onChange={onChangeStyleSize}
             />


### PR DESCRIPTION
Inside the options for the paragraph block the Paragraph Font Size showed `Small (20px)` but under the `paragraph-style.scss` it was set to 18px.