### PR TITLE
Fix typo in Eightshift webpack aliases

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,7 +3,7 @@
 import { configure } from '@storybook/react';
 
 // @WP Editor set default window objects.
-require( 'EighshiftBlocksStorybookWindowObjects' );
+require( 'EightshiftBlocksStorybookWindowObjects' );
 
 // Run all storybook stories.
 configure([
@@ -15,10 +15,10 @@ configure([
 ], module);
 
 // @WP Editor set default categories.
-require( 'EighshiftBlocksStorybookDefaultCategories' );
+require( 'EightshiftBlocksStorybookDefaultCategories' );
 
 // @WP Editor Styles.
-require( 'EighshiftBlocksStorybookStyles');
+require( 'EightshiftBlocksStorybookStyles');
 
 // Project styles.
 require( './../blocks/init/assets/styles/application.scss');

--- a/blocks/init/assets/scripts/application.js
+++ b/blocks/init/assets/scripts/application.js
@@ -6,5 +6,5 @@
  * @since 1.0.0
  */
 
-import 'EighshiftBlocksBabelPolyfill';
-import 'EighshiftBlocksWhatwgFetch';
+import 'EightshiftBlocksBabelPolyfill';
+import 'EightshiftBlocksWhatwgFetch';

--- a/blocks/init/assets/styles/application.scss
+++ b/blocks/init/assets/styles/application.scss
@@ -7,7 +7,7 @@
  */
 
 // Vendors - node modules
-@import 'EighshiftBlocksNormalize';
+@import 'EightshiftBlocksNormalize';
 @include normalize(); // stylelint-disable-line at-rule-empty-line-before
 
 // Globals.

--- a/blocks/init/assets/styles/parts/_shared.scss
+++ b/blocks/init/assets/styles/parts/_shared.scss
@@ -1,6 +1,6 @@
 // Vendors - node modules
-@import 'EighshiftBlocksMediaBlender';
-@import 'EighshiftFrontendLibs';
+@import 'EightshiftBlocksMediaBlender';
+@import 'EightshiftFrontendLibs';
 
 // Project specific.
 @import 'utils/colors';

--- a/blocks/init/src/blocks/assets/scripts/application-blocks-editor.js
+++ b/blocks/init/src/blocks/assets/scripts/application-blocks-editor.js
@@ -13,7 +13,7 @@
  * @since 1.0.0
  */
 
-import { registerBlocks } from 'EighshiftBlocksRegisterBlocks';
+import { registerBlocks } from 'EightshiftBlocksRegisterBlocks';
 import { Wrapper } from './../../wrapper/wrapper';
 import blocksSettings from './../../manifest.json';
 

--- a/blocks/init/src/blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/blocks/assets/scripts/application-blocks.js
@@ -11,7 +11,7 @@
  *
  * @since 1.0.0
  */
-import { dynamicImport } from 'EighshiftBlocksDynamicImport';
+import { dynamicImport } from 'EightshiftBlocksDynamicImport';
 
 // Find all blocks and require assets index.js inside it.
 dynamicImport(require.context('./../../custom', true, /assets\/index\.js$/));

--- a/blocks/init/src/blocks/assets/styles/application-blocks-editor.scss
+++ b/blocks/init/src/blocks/assets/styles/application-blocks-editor.scss
@@ -14,7 +14,7 @@
 @import './../../../../assets/styles/parts/shared';
 
 // Ovveride default editor styles.
-@import 'EighshiftEditorStyleOverride';
+@import 'EightshiftEditorStyleOverride';
 
 // Register Wrapper block styles.
 @import './../../wrapper/wrapper-editor.scss';

--- a/blocks/init/src/blocks/components/button/components/button-options.js
+++ b/blocks/init/src/blocks/components/button/components/button-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/editor';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, TextControl, Icon, BaseControl } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/heading/components/heading-options.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-options.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, Icon } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/heading/components/heading-toolbar.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-toolbar.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { AlignmentToolbar } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
-import { HeadingLevel } from 'EighshiftComponentHeadingLevel';
+import { HeadingLevel } from 'EightshiftComponentHeadingLevel';
 
 export const HeadingToolbar = (props) => {
   const {

--- a/blocks/init/src/blocks/components/link/components/link-options.js
+++ b/blocks/init/src/blocks/components/link/components/link-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/editor';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { ToggleControl, Icon, BaseControl } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
+++ b/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, Icon } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/custom/button/button-block.js
+++ b/blocks/init/src/blocks/custom/button/button-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ButtonEditor } from './components/button-editor';
 import { ButtonOptions } from './components/button-options';

--- a/blocks/init/src/blocks/custom/button/docs/story.js
+++ b/blocks/init/src/blocks/custom/button/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from './../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/card-list/card-list-block.js
+++ b/blocks/init/src/blocks/custom/card-list/card-list-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CardListEditor } from './components/card-list-editor';
 import { CardListOptions } from './components/card-list-options';

--- a/blocks/init/src/blocks/custom/card-list/docs/story.js
+++ b/blocks/init/src/blocks/custom/card-list/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/card/card-block.js
+++ b/blocks/init/src/blocks/custom/card/card-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CardEditor } from './components/card-editor';
 import { CardOptions } from './components/card-options';

--- a/blocks/init/src/blocks/custom/card/docs/story.js
+++ b/blocks/init/src/blocks/custom/card/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/cards-grid/cards-grid-block.js
+++ b/blocks/init/src/blocks/custom/cards-grid/cards-grid-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CardsGridEditor } from './components/cards-grid-editor';
 

--- a/blocks/init/src/blocks/custom/cards-grid/docs/story.js
+++ b/blocks/init/src/blocks/custom/cards-grid/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/cards-list/cards-list-block.js
+++ b/blocks/init/src/blocks/custom/cards-list/cards-list-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CardsListEditor } from './components/cards-list-editor';
 

--- a/blocks/init/src/blocks/custom/cards-list/docs/story.js
+++ b/blocks/init/src/blocks/custom/cards-list/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/carousel-image/carousel-image-block.js
+++ b/blocks/init/src/blocks/custom/carousel-image/carousel-image-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CarouselImageOptions } from './components/carousel-image-options';
 import { CarouselImageEditor } from './components/carousel-image-editor';

--- a/blocks/init/src/blocks/custom/carousel-image/docs/story.js
+++ b/blocks/init/src/blocks/custom/carousel-image/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/carousel/assets/carousel-slider.js
+++ b/blocks/init/src/blocks/custom/carousel/assets/carousel-slider.js
@@ -1,5 +1,5 @@
-import Swiper from 'EighshiftBlocksSwiper';
-import { media } from 'EighshiftBlocksUtilityHelpersPath/media';
+import Swiper from 'EightshiftBlocksSwiper';
+import { media } from 'EightshiftBlocksUtilityHelpersPath/media';
 
 export class CarouselSlider {
   constructor(defaultElement) {

--- a/blocks/init/src/blocks/custom/carousel/carousel-block.js
+++ b/blocks/init/src/blocks/custom/carousel/carousel-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CarouselOptions } from './components/carousel-options';
 import { CarouselEditor } from './components/carousel-editor';

--- a/blocks/init/src/blocks/custom/carousel/carousel-style.scss
+++ b/blocks/init/src/blocks/custom/carousel/carousel-style.scss
@@ -1,4 +1,4 @@
-@import 'EighshiftBlocksSwiperStyle';
+@import 'EightshiftBlocksSwiperStyle';
 
 .block-carousel {
   &[data-swiper-freeMode='1'] {

--- a/blocks/init/src/blocks/custom/carousel/docs/story.js
+++ b/blocks/init/src/blocks/custom/carousel/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/divider/components/divider-options.js
+++ b/blocks/init/src/blocks/custom/divider/components/divider-options.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import globalSettings from './../../../manifest.json';
 
 export const DividerOptions = (props) => {

--- a/blocks/init/src/blocks/custom/divider/divider-block.js
+++ b/blocks/init/src/blocks/custom/divider/divider-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { DividerEditor } from './components/divider-editor';
 import { DividerOptions } from './components/divider-options';

--- a/blocks/init/src/blocks/custom/divider/docs/story.js
+++ b/blocks/init/src/blocks/custom/divider/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/example/docs/story.js
+++ b/blocks/init/src/blocks/custom/example/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from './../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/example/example-block.js
+++ b/blocks/init/src/blocks/custom/example/example-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls, BlockControls } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ExampleEditor } from './components/example-editor';
 import { ExampleOptions } from './components/example-options';

--- a/blocks/init/src/blocks/custom/group/docs/story.js
+++ b/blocks/init/src/blocks/custom/group/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, blockInnerBlocks, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/heading/docs/story.js
+++ b/blocks/init/src/blocks/custom/heading/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/heading/heading-block.js
+++ b/blocks/init/src/blocks/custom/heading/heading-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { HeadingEditor } from './components/heading-editor';
 import { HeadingOptions } from './components/heading-options';

--- a/blocks/init/src/blocks/custom/image/docs/story.js
+++ b/blocks/init/src/blocks/custom/image/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/image/image-block.js
+++ b/blocks/init/src/blocks/custom/image/image-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ImageEditor } from './components/image-editor';
 import { ImageOptions } from './components/image-options';

--- a/blocks/init/src/blocks/custom/jumbotron/docs/story.js
+++ b/blocks/init/src/blocks/custom/jumbotron/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/jumbotron/jumbotron-block.js
+++ b/blocks/init/src/blocks/custom/jumbotron/jumbotron-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { JumbotronEditor } from './components/jumbotron-editor';
 import { JumbotronOptions } from './components/jumbotron-options';

--- a/blocks/init/src/blocks/custom/link/docs/story.js
+++ b/blocks/init/src/blocks/custom/link/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from './../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/link/link-block.js
+++ b/blocks/init/src/blocks/custom/link/link-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { LinkEditor } from './components/link-editor';
 import { LinkOptions } from './components/link-options';

--- a/blocks/init/src/blocks/custom/lists-info/docs/story.js
+++ b/blocks/init/src/blocks/custom/lists-info/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/lists-info/lists-info-block.js
+++ b/blocks/init/src/blocks/custom/lists-info/lists-info-block.js
@@ -1,6 +1,6 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ListsInfoEditor } from './components/lists-info-editor';
 

--- a/blocks/init/src/blocks/custom/lists/docs/story.js
+++ b/blocks/init/src/blocks/custom/lists/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/lists/lists-block.js
+++ b/blocks/init/src/blocks/custom/lists/lists-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ListsEditor } from './components/lists-editor';
 

--- a/blocks/init/src/blocks/custom/paragraph/docs/story.js
+++ b/blocks/init/src/blocks/custom/paragraph/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/paragraph/paragraph-block.js
+++ b/blocks/init/src/blocks/custom/paragraph/paragraph-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { ParagraphEditor } from './components/paragraph-editor';
 import { ParagraphOptions } from './components/paragraph-options';

--- a/blocks/init/src/blocks/custom/quote/docs/story.js
+++ b/blocks/init/src/blocks/custom/quote/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/quote/quote-block.js
+++ b/blocks/init/src/blocks/custom/quote/quote-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { QuoteEditor } from './components/quote-editor';
 

--- a/blocks/init/src/blocks/custom/video/docs/story.js
+++ b/blocks/init/src/blocks/custom/video/docs/story.js
@@ -1,4 +1,4 @@
-import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EighshiftBlocksStorybookHelpers';
+import { Gutenberg, blockDetails, hasWrapperDecorator } from 'EightshiftBlocksStorybookHelpers';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import manifest from '../manifest.json';
 import readme from './readme.md';

--- a/blocks/init/src/blocks/custom/video/video-block.js
+++ b/blocks/init/src/blocks/custom/video/video-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { VideoEditor } from './components/video-editor';
 import { VideoOptions } from './components/video-options';

--- a/blocks/init/src/blocks/wrapper/components/wrapper-options.js
+++ b/blocks/init/src/blocks/wrapper/components/wrapper-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody, TextControl, Dashicon, TabPanel, Icon } from '@wordpress/components';
-import { ColorPaletteCustom } from 'EighshiftComponentColorPalette';
+import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { WrapperResponsiveTabContent } from './wrapper-responsive-tab-content';
 import globalSettings from '../../manifest.json';
 

--- a/blocks/init/src/blocks/wrapper/wrapper.js
+++ b/blocks/init/src/blocks/wrapper/wrapper.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { WrapperEditor } from './components/wrapper-editor';
 import { WrapperOptions } from './components/wrapper-options';

--- a/documentation/documentation/sassdocs.md
+++ b/documentation/documentation/sassdocs.md
@@ -5,22 +5,22 @@ For years we have collected a list of useful SASS mixins, functions, and all oth
 **Visit [SassDocs](https://infinum.github.io/eightshift-frontend-libs/sassdocs/) for more details.**
 
 ## Default usage
-Sass mixing, functions, helpers are located in `node_modules/@eighshift/frontent-libs/styles/scss/eightshift-frontend-libs.scss` file. If you are using our webpack build then you are all set, and you can use it by importing it to your project like this:
+Sass mixing, functions, helpers are located in `node_modules/@Eightshift/frontent-libs/styles/scss/eightshift-frontend-libs.scss` file. If you are using our webpack build then you are all set, and you can use it by importing it to your project like this:
 
 ```scss
-@import 'EighshiftFrontendLibs';
+@import 'EightshiftFrontendLibs';
 ```
 
 ## Not using Webpack Build
 
-To be able to use `EighshiftFrontendLibs` as a shorthand, we have provided and `alias` in our webpack build under the `resolve` object key.
+To be able to use `EightshiftFrontendLibs` as a shorthand, we have provided and `alias` in our webpack build under the `resolve` object key.
 
 If you don't use our full build for some reason and want only to use Eightshift Frontend Libs you can provide this in your webpack build:
 
 ```js
 resolve: {
   alias: {
-    EighshiftFrontendLibs: path.resolve('node_modules', '@eightshift', 'frontend-libs', 'styles', 'scss', 'eightshift-frontend-libs.scss'),
+    EightshiftFrontendLibs: path.resolve('node_modules', '@eightshift', 'frontend-libs', 'styles', 'scss', 'eightshift-frontend-libs.scss'),
   }
 }
 ```
@@ -28,7 +28,7 @@ resolve: {
 and then importing it like this:
 
 ```scss
-@import 'EighshiftFrontendLibs';
+@import 'EightshiftFrontendLibs';
 ```
 
 or you can import it directly like this, but be careful where your node_modules folder is located:

--- a/documentation/helpers/aliases.md
+++ b/documentation/helpers/aliases.md
@@ -10,7 +10,7 @@ It finds all files recursively in the folder using regex. This example will requ
 
 #### Usage
 ```js
-import { dynamicImport } from 'EighshiftBlocksDynamicImport';
+import { dynamicImport } from 'EightshiftBlocksDynamicImport';
 
 dynamicImport(require.context('./../../custom', true, /assets\/index.js$/));
 ```
@@ -21,7 +21,7 @@ Converts the first letter of the string to uppercase.
 
 #### Usage
 ```js
-import { ucfirst } from 'EighshiftBlocksUcfirst';
+import { ucfirst } from 'EightshiftBlocksUcfirst';
 
 ucfirst('custom string');
 ```
@@ -34,7 +34,7 @@ This alias provides only path to helpers folder.
 
 #### Usage
 ```js
-import { media } from 'EighshiftBlocksUtilityHelpersPath/media';
+import { media } from 'EightshiftBlocksUtilityHelpersPath/media';
 ```
 
 ## JavaScript WhatwgFetch
@@ -43,7 +43,7 @@ Alias providing [Whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch). Chec
 
 #### Usage
 ```js
-import 'EighshiftBlocksWhatwgFetch';
+import 'EightshiftBlocksWhatwgFetch';
 ```
 
 ## JavaScript Swiper
@@ -54,12 +54,12 @@ Alias providing [Swiper](https://www.npmjs.com/package/swiper). Check documentat
 
 JavaScript
 ```js
-import 'EighshiftBlocksSwiper';
+import 'EightshiftBlocksSwiper';
 ```
 
 Styles:
 ```scss
-@import 'EighshiftBlocksSwiperStyle';
+@import 'EightshiftBlocksSwiperStyle';
 ```
 
 ## JavaScript Babel Polyfill
@@ -69,18 +69,18 @@ Alias providing [Babel Polyfill](https://babeljs.io/docs/en/babel-polyfill). Che
 #### Usage
 
 ```js
-import 'EighshiftBlocksBabelPolyfill';
+import 'EightshiftBlocksBabelPolyfill';
 ```
 
-## Scss EighshiftFrontendLibs
+## Scss EightshiftFrontendLibs
 
-Alias providing [Eighshift Frontend Libs](https://infinum.github.io/eightshift-frontend-libs/sassdocs/). 
+Alias providing [Eightshift Frontend Libs](https://infinum.github.io/eightshift-frontend-libs/sassdocs/).
 
 #### Usage
 
 Styles:
 ```scss
-@import 'EighshiftFrontendLibs';
+@import 'EightshiftFrontendLibs';
 ```
 
 ## Scss Normalize
@@ -91,7 +91,7 @@ Alias providing [Normalize](https://www.npmjs.com/package/normalize-scss). Check
 
 Styles:
 ```scss
-@import 'EighshiftBlocksNormalize';
+@import 'EightshiftBlocksNormalize';
 @include normalize(); // stylelint-disable-line at-rule-empty-line-before
 ```
 
@@ -103,7 +103,7 @@ Alias providing [Media Blender](https://github.com/infinum/media-blender). Check
 
 Styles:
 ```scss
-@import 'EighshiftBlocksMediaBlender';
+@import 'EightshiftBlocksMediaBlender';
 ```
 
 ## Scss EditorStyleOverride
@@ -114,5 +114,5 @@ It provides the Block Editor overrides on some styles to give better UX for our 
 
 Styles:
 ```scss
-@import 'EighshiftEditorStyleOverride';
+@import 'EightshiftEditorStyleOverride';
 ```

--- a/documentation/helpers/get-actions.md
+++ b/documentation/helpers/get-actions.md
@@ -5,7 +5,7 @@ Actions are passed in child components in order to update props on an event (`on
 
 ## Default Attribute
 
-Default function output is `onChange` + attribute name.  
+Default function output is `onChange` + attribute name.
 Example: `onChangeContent`.
 
 Helper is located [here](https://github.com/infinum/eightshift-frontend-libs/blob/d14c02804c1e55fc4ca11af0546a40205fee93a7/scripts/get-actions.js).
@@ -29,7 +29,7 @@ Helper is located [here](https://github.com/infinum/eightshift-frontend-libs/blo
 ### Usage
 
 ```js
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 
 const actions = getActions(props, manifest);
@@ -80,7 +80,7 @@ If attribute needs to save multiple values at the same time for media (images, v
 ### Usage
 
 ```js
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 
 const actions = getActions(props, manifest);
@@ -131,7 +131,7 @@ If attribute needs to save multiple values at the same time, generally used for 
 ### Usage
 
 ```js
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 
 const actions = getActions(props, manifest);

--- a/documentation/structure/creating-block-from-components.md
+++ b/documentation/structure/creating-block-from-components.md
@@ -1,6 +1,6 @@
 # Creating Block from Components
 
-You may wonder: what is the difference between components and blocks? Aren't they the same thing? 
+You may wonder: what is the difference between components and blocks? Aren't they the same thing?
 
 They are similar, but not the same. Components are, for lack of a better word, _dumb_. They aren't bothered with the context and they are **reusable**.
 This is the key word in this whole ordeal. One component may be reused in different blocks. Also, the main difference is that the component is not registered in WordPress; its sole purpose is to provide reusable parts for your blocks.
@@ -21,7 +21,7 @@ First we'll create a block in the `src/blocks/custom/card` folder. The folder st
 | |card.php
 | |card-style.scss
 | |manifest.json
-``` 
+```
 
 The `manifest.json` will hold all the default attributes and data about the new block
 
@@ -168,7 +168,7 @@ Back to the block, we need to create the `edit` method functionality and the vie
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
-import { getActions } from 'EighshiftBlocksGetActions';
+import { getActions } from 'EightshiftBlocksGetActions';
 import manifest from './manifest.json';
 import { CardEditor } from './components/card-editor';
 import { CardOptions } from './components/card-options';
@@ -199,8 +199,8 @@ export const Card = (props) => {
 };
 ```
 
-Here we'll use our ready made component (built out of other components - reusability), and wrap it in [React Fragment](https://reactjs.org/docs/fragments.html). It is a pattern used so that we can return multiple elements.  
-Another thing you'll note is the usage of `<InspectorControls />` [component](https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inspector-controls). It is used to display settings of the block in the sidebar (in our case our options that contain the image upload component).  
+Here we'll use our ready made component (built out of other components - reusability), and wrap it in [React Fragment](https://reactjs.org/docs/fragments.html). It is a pattern used so that we can return multiple elements.
+Another thing you'll note is the usage of `<InspectorControls />` [component](https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inspector-controls). It is used to display settings of the block in the sidebar (in our case our options that contain the image upload component).
 Lastly, both our `<CardEditor />` and `<InspectorControls />` are wrapped in the `<Fragment />` wrapper due to Reacts one top-level element rule. If your block doesn't have Options, you can only have `<CardEditor />` component in here.
 
 ### PHP view
@@ -274,7 +274,7 @@ Notice how we used
 ?>
 ```
 
-To render out our `image` component. Again, we're showing the power of reusability here. 
+To render out our `image` component. Again, we're showing the power of reusability here.
 
 ### Styling
 

--- a/webpack/gutenberg.js
+++ b/webpack/gutenberg.js
@@ -57,29 +57,29 @@ module.exports = (options) => {
       alias: {
 
         // Block Helpers.
-        EighshiftBlocksDynamicImport: path.resolve(__dirname, '..', 'scripts', 'dynamic-import'),
-        EighshiftBlocksRegisterBlocks: path.resolve(__dirname, '..', 'scripts', 'register-blocks'),
-        EighshiftBlocksUcfirst: path.resolve(__dirname, '..', 'scripts', 'ucfirst'),
-        EighshiftBlocksGetActions: path.resolve(__dirname, '..', 'scripts', 'get-actions'),
-        EighshiftBlocksStorybookHelpers: path.resolve(__dirname, '..', '.storybook', 'helpers'),
-        EighshiftBlocksUtilityHelpersPath: path.resolve(__dirname, '..', 'scripts', 'helpers'),
+        EightshiftBlocksDynamicImport: path.resolve(__dirname, '..', 'scripts', 'dynamic-import'),
+        EightshiftBlocksRegisterBlocks: path.resolve(__dirname, '..', 'scripts', 'register-blocks'),
+        EightshiftBlocksUcfirst: path.resolve(__dirname, '..', 'scripts', 'ucfirst'),
+        EightshiftBlocksGetActions: path.resolve(__dirname, '..', 'scripts', 'get-actions'),
+        EightshiftBlocksStorybookHelpers: path.resolve(__dirname, '..', '.storybook', 'helpers'),
+        EightshiftBlocksUtilityHelpersPath: path.resolve(__dirname, '..', 'scripts', 'helpers'),
 
         // JavaScript
-        EighshiftBlocksWhatwgFetch: path.resolve(options.config.libNodeModules, 'whatwg-fetch'),
-        EighshiftBlocksSwiper: path.resolve(options.config.libNodeModules, 'swiper'),
-        EighshiftBlocksBabelPolyfill: path.resolve(options.config.libNodeModules, '@babel/polyfill'),
-        EighshiftBlocksAutoprefixer: path.resolve(options.config.libNodeModules, 'autoprefixer'),
+        EightshiftBlocksWhatwgFetch: path.resolve(options.config.libNodeModules, 'whatwg-fetch'),
+        EightshiftBlocksSwiper: path.resolve(options.config.libNodeModules, 'swiper'),
+        EightshiftBlocksBabelPolyfill: path.resolve(options.config.libNodeModules, '@babel/polyfill'),
+        EightshiftBlocksAutoprefixer: path.resolve(options.config.libNodeModules, 'autoprefixer'),
 
         // Scss.
-        EighshiftFrontendLibs: path.resolve(__dirname, '..', 'styles', 'scss', 'eightshift-frontend-libs.scss'),
-        EighshiftBlocksNormalize: path.resolve(options.config.libNodeModules, 'normalize-scss'),
-        EighshiftBlocksMediaBlender: path.resolve(options.config.libNodeModules, 'media-blender'),
-        EighshiftBlocksSwiperStyle: path.resolve(options.config.libNodeModules, 'swiper', 'swiper.scss'),
-        EighshiftEditorStyleOverride: path.resolve(__dirname, '..', 'styles', 'blocks', 'override-editor.scss'),
+        EightshiftFrontendLibs: path.resolve(__dirname, '..', 'styles', 'scss', 'eightshift-frontend-libs.scss'),
+        EightshiftBlocksNormalize: path.resolve(options.config.libNodeModules, 'normalize-scss'),
+        EightshiftBlocksMediaBlender: path.resolve(options.config.libNodeModules, 'media-blender'),
+        EightshiftBlocksSwiperStyle: path.resolve(options.config.libNodeModules, 'swiper', 'swiper.scss'),
+        EightshiftEditorStyleOverride: path.resolve(__dirname, '..', 'styles', 'blocks', 'override-editor.scss'),
 
         // Components.
-        EighshiftComponentColorPalette: path.resolve(__dirname, '..', 'components', 'color-palette-custom', 'color-palette-custom.js'),
-        EighshiftComponentHeadingLevel: path.resolve(__dirname, '..', 'components', 'heading-level', 'heading-level.js'),
+        EightshiftComponentColorPalette: path.resolve(__dirname, '..', 'components', 'color-palette-custom', 'color-palette-custom.js'),
+        EightshiftComponentHeadingLevel: path.resolve(__dirname, '..', 'components', 'heading-level', 'heading-level.js'),
       },
     },
   };

--- a/webpack/storybook.js
+++ b/webpack/storybook.js
@@ -16,10 +16,10 @@ module.exports = ({ config }) => {
   config.resolve.alias = {
     ...config.resolve.alias,
     ...gutenberg.resolve.alias,
-    EighshiftBlocksStorybookWindowObjects: path.resolve(__dirname, '..', '.storybook', 'parts', 'window-objects'),
-    EighshiftBlocksStorybookDefaultCategories: path.resolve(__dirname, '..', '.storybook', 'parts', 'default-categories'),
-    EighshiftBlocksStorybookStyles: path.resolve(__dirname, '..', '.storybook', 'parts', 'styles.scss'),
-    EighshiftBlocksStorybookAddons: path.resolve(__dirname, '..', '.storybook', 'addons'),
+    EightshiftBlocksStorybookWindowObjects: path.resolve(__dirname, '..', '.storybook', 'parts', 'window-objects'),
+    EightshiftBlocksStorybookDefaultCategories: path.resolve(__dirname, '..', '.storybook', 'parts', 'default-categories'),
+    EightshiftBlocksStorybookStyles: path.resolve(__dirname, '..', '.storybook', 'parts', 'styles.scss'),
+    EightshiftBlocksStorybookAddons: path.resolve(__dirname, '..', '.storybook', 'addons'),
   };
 
   /**


### PR DESCRIPTION
Searched and replaced all instances of `Eighshift` with `Eightshift`

Tested the changes with building and running storybook, docpress and sassdoc.