### PR TITLE
Added block manifest registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,23 @@ All notable changes to this project will be documented in this file.
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
 ## [Unreleased]
+
+## Added
 - Added `.travis.yml`.
 - Added integration test for setting up a plugin using `npx create-wp-project plugin`.
-- Made `create-wp-project` tests run in travis.
+- Added `create-wp-project` tests run in travis.
+- Added auto detection of React version to eslint config..
+- Added footer & header to copy blocks script.
+- Added foreground color for icons.
+- Added underline-text mixin.
+- Added underline mixin.
+- Added for-each-attribute mixin.
+- Added block manifesdt registration ability to register blocks in different manifest than global settings.
+
+## Changed
 - Moved all tests from `create-wp-project` to `eightshift-frontend-libs`.
-- Linting fixes.
-- Added auto detection of React version to eslint config.
 - Refactoring stories to simpler setup.
-- Added footer & header to copy blocks script
-
-- Added foreground color for icons
-
-- Added underline-text mixin
-- Added underline mixin
-- Added for-each-attribute mixin
+- Linting fixes.
 
 ## [3.0.11] - 2020-01-29
 

--- a/scripts/register-block.js
+++ b/scripts/register-block.js
@@ -15,6 +15,7 @@ import { withWrapper } from './with-wrapper';
  */
 export const registerBlock = (manifest, blocksSettings, edit, wrapper = null) => {
   const {
+    namespace,
     blockName,
     title,
     description,
@@ -40,7 +41,6 @@ export const registerBlock = (manifest, blocksSettings, edit, wrapper = null) =>
   } = manifest;
 
   const {
-    namespace,
     background: backgroundGlobal,
     foreground: foregroundGlobal,
   } = blocksSettings;
@@ -60,8 +60,11 @@ export const registerBlock = (manifest, blocksSettings, edit, wrapper = null) =>
     save = () => createElement(InnerBlocks.Content);
   }
 
+  // Check if namespace is defined in block or in global manifest settings.
+  const namespaceFinal = (typeof namespace === 'undefined') ? blocksSettings.namespace : namespace;
+
   return {
-    blockName: `${namespace}/${blockName}`,
+    blockName: `${namespaceFinal}/${blockName}`,
     options: {
       title,
       description,


### PR DESCRIPTION
Added block manifest registration ability to register blocks in different namespace than global settings.

By default all blocks take namespace from global namespace but now you can provide namespace in each block and it will take that as default.

also I have fixed change-log a little bit.

This is in combination with PR on the Eightshift-Libs (https://github.com/infinum/eightshift-libs/pull/43)