### PR TITLE
Add new alias for swiper with IE11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Added underline mixin.
 - Added for-each-attribute mixin.
 - Added block manifest registration ability to register blocks in different manifest than global settings.
+- Added new alias `EightshiftBlocksSwiperIE` for Swiper slider with IE 11 support.
 
 ## Changed
 - Moved all tests from `create-wp-project` to `eightshift-frontend-libs`.
 - Refactoring stories to simpler setup.
 - Linting fixes.
+- Removed jQuery from scroll-to-top component and carousel.
 
 - Added footer component
 - Added copyright component

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -14,6 +14,7 @@ module.exports = (packagesPath) => {
         // Node Modules.
         EightshiftBlocksWhatwgFetch: path.resolve(packagesPath.nodeModulesPath, 'whatwg-fetch'),
         EightshiftBlocksSwiper: path.resolve(packagesPath.nodeModulesPath, 'swiper'),
+        EightshiftBlocksSwiperIE: path.resolve(packagesPath.nodeModulesPath, 'swiper/js/swiper.min'),
         EightshiftBlocksBabelPolyfill: path.resolve(packagesPath.nodeModulesPath, '@babel/polyfill'),
         EightshiftBlocksAutoprefixer: path.resolve(packagesPath.nodeModulesPath, 'autoprefixer'),
         EightshiftBlocksNormalize: path.resolve(packagesPath.nodeModulesPath, 'normalize-scss'),


### PR DESCRIPTION
- added new alias `EightshiftBlocksSwiperIE` for Swiper slider support in IE 11 browser