### PR TITLE
Fixing broken build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+* Wrong namespace in components helpers.
+* Removing unnecessary map keys for components style.
+* Fixing drawer styles.
+* Fixing menu styles.
+* Loading z-index from external map.
+* Fixing typo translate3D to translate3d.
+* Removing display: inline-block;
+* Fixing logo styles.
+* Fixing broken scroll to top method.
+
 ## [3.1.0] - 2020-03-04
 
 ## Added

--- a/blocks/init/assets/styles/parts/utils/_z-index.scss
+++ b/blocks/init/assets/styles/parts/utils/_z-index.scss
@@ -3,5 +3,8 @@ $zindex map should be used to define all project indexes.
 It gives you an overview of all indexes and helps you when debug z-index issues.
 */
 
-// $zindex: (
-// );
+$zindex: (
+  header: 100,
+  drawer: 99,
+  overlay: 98,
+);

--- a/blocks/init/src/blocks/components/copyright/docs/readme.md
+++ b/blocks/init/src/blocks/components/copyright/docs/readme.md
@@ -15,7 +15,7 @@ None
 ## Example call
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'copyright' );
 

--- a/blocks/init/src/blocks/components/drawer/drawer-style.scss
+++ b/blocks/init/src/blocks/components/drawer/drawer-style.scss
@@ -1,16 +1,10 @@
 $drawer: (
-  width: 256px,
+  width: 250px,
   colors: (
     background: $base-white-color,
-    link: $base-text-color,
-    link-hover: $base-primary-color
   ),
-  navigation: (
-    font-size: 24px,
-    font-family: $base-font-family
-  ),
-  link-offset: 24px,
-  vertical-padding: 26px,
+  padding: 25px,
+  z-index: map-get-strict($zindex, drawer),
 );
 
 .drawer {
@@ -18,9 +12,9 @@ $drawer: (
   position: fixed;
   top: auto;
   height: 100%;
-  z-index: 99;
+  z-index: map-get-strict($drawer, z-index);
   margin: auto;
-  padding: map-get-strict($drawer, vertical-padding);
+  padding: map-get-strict($drawer, padding);
   display: block;
   background: map-get-deep($drawer, colors, background);
   width: map-get-strict($drawer, width);
@@ -32,17 +26,17 @@ $drawer: (
 
   &--left {
     left: 0;
-    transform: translate3D(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
   }
 
   &--right {
     right: 0;
-    transform: translate3D(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
   }
 }
 
 body.menu-is-open {
   .drawer {
-    transform: translate3D(0, 0, 0);
+    transform: translate3d(0, 0, 0);
   }
 }

--- a/blocks/init/src/blocks/components/drawer/drawer.php
+++ b/blocks/init/src/blocks/components/drawer/drawer.php
@@ -10,7 +10,7 @@
 
 namespace Eightshift_Boilerplate\Blocks;
 
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 $block_class     = $attributes['blockClass'] ?? 'drawer';
 $drawer_position = $attributes['drawerPosition'] ?? 'left';

--- a/blocks/init/src/blocks/components/footer/docs/readme.md
+++ b/blocks/init/src/blocks/components/footer/docs/readme.md
@@ -22,7 +22,7 @@ components/menu
 ## Example
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'footer', [
   'leftComponent' => Components::render( 'copyright' ),

--- a/blocks/init/src/blocks/components/footer/footer-style.scss
+++ b/blocks/init/src/blocks/components/footer/footer-style.scss
@@ -1,6 +1,5 @@
-$base-footer-height: 50px;
 $footer: (
-  height: $base-footer-height,
+  height: 50px,
   site-padding: $base-gutter-size,
   site-container: $base-container-size,
   colors: (

--- a/blocks/init/src/blocks/components/footer/footer.php
+++ b/blocks/init/src/blocks/components/footer/footer.php
@@ -9,7 +9,7 @@
 
 namespace Eightshift_Boilerplate\Blocks;
 
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 $block_class      = $attributes['blockClass'] ?? 'footer';
 $left_component   = ! empty( $attributes['leftComponent'] ) ? Components::ensure_string( $attributes['leftComponent'] ) : '';

--- a/blocks/init/src/blocks/components/hamburger/docs/readme.md
+++ b/blocks/init/src/blocks/components/hamburger/docs/readme.md
@@ -13,7 +13,7 @@ None
 ## Example call
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'hamburger' );
 

--- a/blocks/init/src/blocks/components/hamburger/hamburger-style.scss
+++ b/blocks/init/src/blocks/components/hamburger/hamburger-style.scss
@@ -19,10 +19,7 @@ $hamburger: (
   height: 100%;
   padding: map-get-strict($hamburger, padding);
   margin: 0 -#{map-get-strict($hamburger, padding)};
-  position: relative;
-  z-index: 100;
   cursor: pointer;
-  display: inline-block;
 
   @include media(desktop up) {
     display: none;

--- a/blocks/init/src/blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/blocks/components/hamburger/hamburger.php
@@ -7,7 +7,7 @@
 
 namespace Eightshift_Boilerplate\Blocks;
 
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 $block_class = $attributes['blockClass'] ?? 'hamburger';
 

--- a/blocks/init/src/blocks/components/header/docs/readme.md
+++ b/blocks/init/src/blocks/components/header/docs/readme.md
@@ -24,7 +24,7 @@ components/drawer
 ## Example
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'header', [
   'leftComponent' => [

--- a/blocks/init/src/blocks/components/header/header-style.scss
+++ b/blocks/init/src/blocks/components/header/header-style.scss
@@ -5,6 +5,7 @@ $header: (
   colors: (
     background: $base-white-color,
   ),
+  z-index: map-get-strict($zindex, header),
 );
 
 .header {
@@ -15,7 +16,7 @@ $header: (
   height: map-get-strict($header, height);
   width: 100%;
   position: relative;
-  z-index: 100;
+  z-index: map-get-strict($header, z-index);
 
   &--fixed {
     position: fixed;
@@ -35,7 +36,6 @@ $header: (
     flex: 1 0 auto;
     height: 100%;
     position: relative;
-    z-index: 100;
 
     &--center {
       text-align: center;
@@ -61,12 +61,24 @@ $header: (
     }
   }
 
+  &__logo {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include media(desktop up) {
+      justify-content: flex-start;
+    }
+  }
+
   &__menu {
     height: 100%;
     display: none;
 
     @include media(desktop up) {
-      display: block;
+      display: flex;
+      justify-content: flex-end;
     }
   }
 }

--- a/blocks/init/src/blocks/components/header/header.php
+++ b/blocks/init/src/blocks/components/header/header.php
@@ -9,7 +9,7 @@
 
 namespace Eightshift_Boilerplate\Blocks;
 
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 $block_class      = $attributes['blockClass'] ?? 'header';
 $left_component   = ! empty( $attributes['leftComponent'] ) ? Components::ensure_string( $attributes['leftComponent'] ) : '';

--- a/blocks/init/src/blocks/components/logo/docs/readme.md
+++ b/blocks/init/src/blocks/components/logo/docs/readme.md
@@ -18,7 +18,7 @@ None
 ## Example call
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'logo' )
 

--- a/blocks/init/src/blocks/components/logo/logo-style.scss
+++ b/blocks/init/src/blocks/components/logo/logo-style.scss
@@ -3,8 +3,11 @@ $logo: (
 );
 
 .logo {
+  display: block;
+  width: 220px;
+
   &__img {
-    height: map-get-strict($logo, height);
-    width: auto;
+    max-width: 100%;
+    height: auto;
   }
 }

--- a/blocks/init/src/blocks/components/menu/components/horizontal/menu-horizontal-style.scss
+++ b/blocks/init/src/blocks/components/menu/components/horizontal/menu-horizontal-style.scss
@@ -1,39 +1,35 @@
 $menu-horizontal: (
-  link-padding: 16px,
+  link-padding: 0 15px,
   link-modifiers: (
     normal: (
-      color: inherit,
+      color: $base-black-color,
     ),
     hover: (
       color: $base-primary-color,
-    ),
-    active: (
-      color: $base-primary-color,
-    ),
+    )
   ),
 );
 
 .menu-horizontal {
+  @extend %list-reset;
   $this: &;
-  margin: 0;
   height: 100%;
+  display: flex;
+  align-items: center;
 
   &__item {
-    padding-bottom: 0;
     height: 100%;
-    display: inline-block;
   }
 
   &__link {
     text-decoration: none;
-    color: inherit;
-    padding: 0 map-get-strict($menu-horizontal, link-padding);
     height: 100%;
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    position: relative;
+    justify-content: center;
+    padding: map-get-strict($menu-horizontal, link-padding);
     transition: 0.3s color ease-in-out;
 
-    @include link-modifiers($menu-horizontal, link-modifiers);
+    @include link($menu-horizontal, link-modifiers);
   }
 }

--- a/blocks/init/src/blocks/components/menu/components/vertical/menu-vertical-style.scss
+++ b/blocks/init/src/blocks/components/menu/components/vertical/menu-vertical-style.scss
@@ -1,32 +1,24 @@
 $menu-vertical: (
+  link-padding: 10px 0,
   link-modifiers: (
     normal: (
-      color: inherit,
+      color: $base-black-color,
     ),
     hover: (
       color: $base-primary-color,
     ),
-    active: (
-      color: $base-primary-color,
-    ),
   ),
-  padding-navigation: 16px,
 );
 
 .menu-vertical {
-  margin: 0;
-  list-style: none;
-  padding: map-get-strict($menu-vertical, padding-navigation);
-
-  &__item {
-    padding-bottom: 16px;
-  }
+  @extend %list-reset;
 
   &__link {
+    display: block;
     text-decoration: none;
-    color: inherit;
     transition: 0.3s color ease-in-out;
+    padding: map-get-strict($menu-vertical, link-padding);
 
-    @include link-modifiers($menu-horizontal, link-modifiers);
+    @include link($menu-vertical, link-modifiers);
   }
 }

--- a/blocks/init/src/blocks/components/menu/docs/readme.md
+++ b/blocks/init/src/blocks/components/menu/docs/readme.md
@@ -19,7 +19,7 @@ None
 ## Example call
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'menu', [ 'variation' => 'horizontal' ] ) );
 

--- a/blocks/init/src/blocks/components/page-overlay/docs/readme.md
+++ b/blocks/init/src/blocks/components/page-overlay/docs/readme.md
@@ -13,7 +13,7 @@ None
 ## Example call
 
 ```php
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 Components::render( 'page-overlay' ) );
 

--- a/blocks/init/src/blocks/components/page-overlay/page-overlay-style.scss
+++ b/blocks/init/src/blocks/components/page-overlay/page-overlay-style.scss
@@ -1,7 +1,8 @@
 $page-overlay: (
   colors: (
     background: $base-black-color,
-  )
+  ),
+  z-index: map-get-strict($zindex, overlay),
 );
 
 .page-overlay {
@@ -10,7 +11,7 @@ $page-overlay: (
   width: 100%;
   height: 100%;
   background: map-get-deep($page-overlay, colors, background);
-  z-index: 10;
+  z-index: map-get-strict($page-overlay, z-index);
   opacity: 0;
   pointer-events: none;
 

--- a/blocks/init/src/blocks/components/page-overlay/page-overlay.php
+++ b/blocks/init/src/blocks/components/page-overlay/page-overlay.php
@@ -8,7 +8,7 @@
 
 namespace Eightshift_Boilerplate\Blocks;
 
-use Eightshift_Libs\Blocks\Helpers\Components;
+use Eightshift_Libs\Helpers\Components;
 
 $block_class = $attributes['blockClass'] ?? 'page-overlay';
 

--- a/blocks/init/src/blocks/components/scroll-to-top/assets/index.js
+++ b/blocks/init/src/blocks/components/scroll-to-top/assets/index.js
@@ -1,4 +1,4 @@
-import { domReady } from '@wordpress/dom-ready';
+import domReady from '@wordpress/dom-ready';
 
 domReady(() => {
   const selector = '.js-scroll-to-top';


### PR DESCRIPTION
This build was seriously broken.

### Fixed
* Wrong namespace in components helpers.
* Removing unnecessary map keys for components style.
* Fixing drawer styles.
* Fixing menu styles.
* Loading z-index from external map.
* Fixing typo translate3D to translate3d.
* Removing display: inline-block;
* Fixing logo styles.
* Fixing broken scroll to top method.