### PR TITLE
Scroll to target component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 ## [Unreleased]
 * Added `page-overlay` to block copying.
 
+### [Add scroll-to-target component]
+* Added scroll-to-target component that has two options: target element to scroll to and text of the scroll-to link
+
 ## [3.1.1] - 2020-03-05
 
 ### Fixed

--- a/blocks/init/src/blocks/components/scroll-to-target/assets/index.js
+++ b/blocks/init/src/blocks/components/scroll-to-target/assets/index.js
@@ -1,0 +1,19 @@
+import domReady from '@wordpress/dom-ready';
+
+domReady(() => {
+  const selector = '.js-scroll-to-target';
+  const elements = document.querySelectorAll(selector);
+
+  [...elements].forEach((element) => {
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      const target = document.querySelector(event.currentTarget.getAttribute('href'));
+
+      window.scrollTo({
+        top: target.offsetTop,
+        left: 0,
+        behavior: 'smooth',
+      });
+    });
+  });
+});

--- a/blocks/init/src/blocks/components/scroll-to-target/components/scroll-to-target-editor.js
+++ b/blocks/init/src/blocks/components/scroll-to-target/components/scroll-to-target-editor.js
@@ -1,0 +1,14 @@
+import { __ } from '@wordpress/i18n';
+import React from 'react'; // eslint-disable-line no-unused-vars
+
+export const ScrollToTargetEditor = (props) => {
+  const {
+    scrollText,
+  } = props;
+
+  return (
+    <button className="js-scroll-to-target scroll-to-target">
+      {scrollText}
+    </button>
+  );
+};

--- a/blocks/init/src/blocks/components/scroll-to-target/components/scroll-to-target-options.js
+++ b/blocks/init/src/blocks/components/scroll-to-target/components/scroll-to-target-options.js
@@ -1,0 +1,38 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+import { TextControl } from '@wordpress/components';
+
+export const ScrollToTargetOptions = (props) => {
+  const {
+    scrollText,
+    scrollTarget,
+    onChangeScrollText,
+    onChangeScrollTarget,
+  } = props;
+
+  return (
+    <Fragment>
+
+      {onChangeScrollText &&
+        <TextControl
+          label={__('Scroll to text', 'eightshift-boilerplate')}
+          help={__('Text of the scroll to button', 'eightshift-boilerplate')}
+          value={scrollText}
+          onChange={onChangeScrollText}
+        />
+      }
+
+      {onChangeScrollTarget &&
+        <TextControl
+          label={__('Scroll to target', 'eightshift-boilerplate')}
+          help={__('Scroll target. Usually, this is an ID of the element that will be scrolled to', 'eightshift-boilerplate')}
+          value={scrollTarget}
+          onChange={onChangeScrollTarget}
+        />
+      }
+
+    </Fragment>
+  );
+};

--- a/blocks/init/src/blocks/components/scroll-to-target/docs/readme.md
+++ b/blocks/init/src/blocks/components/scroll-to-target/docs/readme.md
@@ -1,0 +1,20 @@
+# Scroll To Target Component
+
+A component used in multiple blocks with all or partial features.
+
+## Dependencies
+
+None
+
+## Implementation
+
+1. Copy/Paste component folder in your project.
+2. Rename `eightshift-boilerplate` namespace to your project's namespace.
+3. Add or remove features you are going to use.
+4. Implement project specific styles.
+5. Implement in your block(s) by providing necessary attributes.
+
+## Usage
+
+This component can be used on any HTML element by simply providing an HTML class defined in `assets/index.js` file.
+

--- a/blocks/init/src/blocks/components/scroll-to-target/docs/story.js
+++ b/blocks/init/src/blocks/components/scroll-to-target/docs/story.js
@@ -1,0 +1,34 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import readme from './readme.md';
+import { ScrollToTargetEditor } from '../components/scroll-to-target-editor';
+import { ScrollToTargetOptions } from '../components/scroll-to-target-options';
+
+export default {
+  title: 'Components|Scroll To Target',
+  parameters: {
+    notes: readme,
+  },
+};
+
+const editorProps = {
+  scrollText: 'Scroll to target',
+};
+
+const optionsProps = {
+  scrollText: 'Scroll to target',
+  scrollTarget: '',
+  onChangeScrollText: () => { },
+  onChangeScrollTarget: () => { },
+};
+
+export const component = () => (
+  <ScrollToTargetEditor
+    {...editorProps}
+  />
+);
+
+export const options = () => (
+  <ScrollToTargetOptions
+    {...optionsProps}
+  />
+);

--- a/blocks/init/src/blocks/components/scroll-to-target/scroll-to-target-style.scss
+++ b/blocks/init/src/blocks/components/scroll-to-target/scroll-to-target-style.scss
@@ -1,0 +1,4 @@
+.scroll-to-target {
+  @extend %button-reset;
+  display: block;
+}

--- a/blocks/init/src/blocks/components/scroll-to-target/scroll-to-target.php
+++ b/blocks/init/src/blocks/components/scroll-to-target/scroll-to-target.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template for the Scroll To Target Component.
+ *
+ * @since 1.0.0
+ * @package Eightshift_Boilerplate\Blocks.
+ */
+
+namespace Eightshift_Boilerplate\Blocks;
+
+$scroll_target = $attributes['scrollTarget'] ?? '';
+$scroll_text   = $attributes['scrollText'] ?? '';
+?>
+
+<a href='<?php echo esc_attr( "#{$scroll_target}" ); ?>' class='js-scroll-to-target scroll-to-target'>
+  <?php echo esc_html( $scroll_text ); ?>
+</a>


### PR DESCRIPTION
Add scroll-to-target component that works similar to scroll-to-top component

Component has options for defining target of the scroll action and text of the scroll-to link.
It works by getting the `href` attribute and scrolling to element with matching `id` attribute