### PR TITLE
Tweak header components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 ## [Unreleased]
 * Added `page-overlay` to block copying.
 
+### [Tweak header components PR]
+* Added support for `behind` and `top` drawers / mobile menus (slide from top or fade in)
+* Better vertical / horizontal centering (more `flex`, less `height`, proper justifying)
+* Removed some `height: 100%` which made styling links difficult and coupled to header / footer height
+* Fixed a bug with centering where logo wouldn't be quite centered on mobile - seemingly due to having `flex-basis` set to auto. Setting it to any other value (such as `1px`) fixed the issue.
+* Fixed a bug where `drawer` wouldn't work if `page-overlay` did not exist
+
 ## [3.1.1] - 2020-03-05
 
 ### Fixed

--- a/blocks/init/src/blocks/components/drawer/assets/drawer.js
+++ b/blocks/init/src/blocks/components/drawer/assets/drawer.js
@@ -31,14 +31,18 @@ export class Drawer {
   }
   
   openMobileMenu() {
+    if (this.overlay) {
+      document.body.classList.add(this.CLASS_OVERLAY_IS_SHOWING);
+    }
     document.body.classList.add(this.CLASS_IS_OPEN);
-    document.body.classList.add(this.CLASS_OVERLAY_IS_SHOWING);
     this.preventScroll();
   }
   
   closeMobileMenu() {
+    if (this.overlay) {
+      document.body.classList.remove(this.CLASS_OVERLAY_IS_SHOWING);
+    }
     document.body.classList.remove(this.CLASS_IS_OPEN);
-    document.body.classList.remove(this.CLASS_OVERLAY_IS_SHOWING);
     this.enableScroll();
   }
   

--- a/blocks/init/src/blocks/components/drawer/assets/drawer.js
+++ b/blocks/init/src/blocks/components/drawer/assets/drawer.js
@@ -10,7 +10,12 @@ export class Drawer {
     this.CLASS_NO_SCROLL = CLASS_NO_SCROLL;
     this.drawer = document.querySelector(selector);
     this.trigger = document.querySelector(`.${this.drawer.getAttribute('data-trigger')}`);
-    this.overlay = document.querySelector(`.${this.drawer.getAttribute('data-overlay')}`);
+    this.overlay = null;
+
+    // Set overlay only if there is one to select.
+    if (this.drawer.getAttribute('data-overlay')) {
+      this.overlay = document.querySelector(`.${this.drawer.getAttribute('data-overlay')}`);
+    }
   }
   
   preventScroll() {

--- a/blocks/init/src/blocks/components/drawer/drawer-style.scss
+++ b/blocks/init/src/blocks/components/drawer/drawer-style.scss
@@ -18,7 +18,7 @@ $drawer: (
   display: block;
   background: map-get-deep($drawer, colors, background);
   width: map-get-strict($drawer, width);
-  transition: transform 0.3s ease-out;
+  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
 
   @include media(desktop up) {
     display: none;
@@ -33,10 +33,22 @@ $drawer: (
     right: 0;
     transform: translate3d(100%, 0, 0);
   }
+
+  &--top {
+    width: 100%;
+    transform: translate3d(0, -100%, 0);
+  }
+
+  &--behind {
+    width: 100%;
+    transform: translate3d(0, 0, 0);
+    opacity: 0;
+  }
 }
 
 body.menu-is-open {
   .drawer {
     transform: translate3d(0, 0, 0);
+    opacity: 1;
   }
 }

--- a/blocks/init/src/blocks/components/footer/footer-style.scss
+++ b/blocks/init/src/blocks/components/footer/footer-style.scss
@@ -28,14 +28,21 @@ $footer: (
 
   &__column {
     flex: 1 0 auto;
-    height: 100%;
+    align-items: center;
+    display: flex;
+
+    &--left {
+      justify-content: flex-start;
+    }
 
     &--center {
       text-align: center;
+      justify-content: center;
     }
 
     &--right {
       text-align: right;
+      justify-content: flex-end;
     }
   }
 }

--- a/blocks/init/src/blocks/components/header/header-style.scss
+++ b/blocks/init/src/blocks/components/header/header-style.scss
@@ -33,26 +33,34 @@ $header: (
   }
 
   &__column {
+    display: flex;
     flex: 1 0 auto;
-    height: 100%;
     position: relative;
+
+    &--left {
+      justify-content: left;
+    }
 
     &--center {
       text-align: center;
+      justify-content: center;
     }
 
     &--right {
       text-align: right;
+      justify-content: flex-end;
     }
 
     @include media(desktop up) {
       &--left {
         order: 2;
+        justify-content: center;
       }
 
       &--center {
-        text-align: left;
         order: 1;
+        text-align: left;
+        justify-content: flex-start;
       }
 
       &--right {

--- a/blocks/init/src/blocks/components/header/header-style.scss
+++ b/blocks/init/src/blocks/components/header/header-style.scss
@@ -34,7 +34,7 @@ $header: (
 
   &__column {
     display: flex;
-    flex: 1 0 auto;
+    flex: 1 0 1px;
     position: relative;
 
     &--left {

--- a/blocks/init/src/blocks/components/menu/components/horizontal/menu-horizontal-style.scss
+++ b/blocks/init/src/blocks/components/menu/components/horizontal/menu-horizontal-style.scss
@@ -17,10 +17,6 @@ $menu-horizontal: (
   display: flex;
   align-items: center;
 
-  &__item {
-    height: 100%;
-  }
-
   &__link {
     text-decoration: none;
     height: 100%;


### PR DESCRIPTION
Changelog
---
* Added support for `behind` and `top` drawers / mobile menus (slide from top or fade in)
* Better vertical / horizontal centering (more `flex`, less `height`, proper justifying)
* Removed some `height: 100%` which made styling links difficult and coupled to header / footer height
* Fixed a bug with centering where logo wouldn't be quite centered on mobile - seemingly due to having `flex-basis` set to auto. Setting it to any other value (such as `1px`) fixed the issue.
* Fixed a bug where `drawer` wouldn't work if `page-overlay` did not exist