### PR TITLE
Remove some aliases with module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 * Added `page-overlay` to block copying.
+* Replaced some aliases with import from module (for example: `import { ColorPaletteCustom } from '@eightshift/frontend-libs`, instead of `import { ColorPaletteCustom } from 'EightshiftComponentColorPalette`)
+  - Had to build an alias for `@eightshift/frontend-libs` in order for this to work while we're working on Storybook from inside the `frontend-libs` repo
 
 ### [Tweak header components PR]
 * Added support for `behind` and `top` drawers / mobile menus (slide from top or fade in)

--- a/blocks/init/src/blocks/assets/scripts/application-blocks-editor.js
+++ b/blocks/init/src/blocks/assets/scripts/application-blocks-editor.js
@@ -13,8 +13,7 @@
  * @since 1.0.0
  */
 
-import { registerBlocks } from 'EightshiftBlocksRegisterBlocks';
-import { dynamicImport } from 'EightshiftBlocksDynamicImport';
+import { registerBlocks, dynamicImport } from '@eightshift/frontend-libs';
 import { Wrapper } from './../../wrapper/wrapper';
 import blocksSettings from './../../manifest.json';
 

--- a/blocks/init/src/blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/blocks/assets/scripts/application-blocks.js
@@ -11,7 +11,7 @@
  *
  * @since 1.0.0
  */
-import { dynamicImport } from 'EightshiftBlocksDynamicImport';
+import { dynamicImport } from '@eightshift/frontend-libs';
 
 // Find all blocks and require assets index.js inside it.
 dynamicImport(require.context('./../../components', true, /assets\/index\.js$/));

--- a/blocks/init/src/blocks/components/button/components/button-options.js
+++ b/blocks/init/src/blocks/components/button/components/button-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/block-editor';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
 import { SelectControl, TextControl, Icon, BaseControl } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/heading/components/heading-options.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-options.js
@@ -1,10 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-
 import { ColorPaletteCustom } from '@eightshift/frontend-libs';
-
-
 import { SelectControl, Icon } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/heading/components/heading-options.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-options.js
@@ -1,7 +1,10 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
+
+
 import { SelectControl, Icon } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/heading/components/heading-toolbar.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-toolbar.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { AlignmentToolbar } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
-import { HeadingLevel } from 'EightshiftComponentHeadingLevel';
+import { HeadingLevel } from '@eightshift/frontend-libs';
 
 export const HeadingToolbar = (props) => {
   const {

--- a/blocks/init/src/blocks/components/link/components/link-options.js
+++ b/blocks/init/src/blocks/components/link/components/link-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/block-editor';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
 import { ToggleControl, Icon, BaseControl } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
+++ b/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
 import { SelectControl, Icon } from '@wordpress/components';
 import globalSettings from './../../../manifest.json';
 

--- a/blocks/init/src/blocks/custom/button/button-block.js
+++ b/blocks/init/src/blocks/custom/button/button-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ButtonEditor } from './components/button-editor';
 import { ButtonOptions } from './components/button-options';

--- a/blocks/init/src/blocks/custom/card-list/card-list-block.js
+++ b/blocks/init/src/blocks/custom/card-list/card-list-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CardListEditor } from './components/card-list-editor';
 import { CardListOptions } from './components/card-list-options';

--- a/blocks/init/src/blocks/custom/card/card-block.js
+++ b/blocks/init/src/blocks/custom/card/card-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CardEditor } from './components/card-editor';
 import { CardOptions } from './components/card-options';

--- a/blocks/init/src/blocks/custom/cards-grid/cards-grid-block.js
+++ b/blocks/init/src/blocks/custom/cards-grid/cards-grid-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CardsGridEditor } from './components/cards-grid-editor';
 

--- a/blocks/init/src/blocks/custom/cards-list/cards-list-block.js
+++ b/blocks/init/src/blocks/custom/cards-list/cards-list-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CardsListEditor } from './components/cards-list-editor';
 

--- a/blocks/init/src/blocks/custom/carousel-image/carousel-image-block.js
+++ b/blocks/init/src/blocks/custom/carousel-image/carousel-image-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CarouselImageOptions } from './components/carousel-image-options';
 import { CarouselImageEditor } from './components/carousel-image-editor';

--- a/blocks/init/src/blocks/custom/carousel/assets/carousel-slider.js
+++ b/blocks/init/src/blocks/custom/carousel/assets/carousel-slider.js
@@ -1,5 +1,5 @@
 import Swiper from 'EightshiftBlocksSwiper';
-import { media } from 'EightshiftBlocksUtilityHelpersPath/media';
+import { media } from '@eightshift/frontend-libs';
 
 export class CarouselSlider {
   constructor(options) {

--- a/blocks/init/src/blocks/custom/carousel/carousel-block.js
+++ b/blocks/init/src/blocks/custom/carousel/carousel-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { CarouselOptions } from './components/carousel-options';
 import { CarouselEditor } from './components/carousel-editor';

--- a/blocks/init/src/blocks/custom/divider/components/divider-options.js
+++ b/blocks/init/src/blocks/custom/divider/components/divider-options.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
 import globalSettings from './../../../manifest.json';
 
 export const DividerOptions = (props) => {

--- a/blocks/init/src/blocks/custom/divider/divider-block.js
+++ b/blocks/init/src/blocks/custom/divider/divider-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { DividerEditor } from './components/divider-editor';
 import { DividerOptions } from './components/divider-options';

--- a/blocks/init/src/blocks/custom/example/example-block.js
+++ b/blocks/init/src/blocks/custom/example/example-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ExampleEditor } from './components/example-editor';
 import { ExampleOptions } from './components/example-options';

--- a/blocks/init/src/blocks/custom/heading/heading-block.js
+++ b/blocks/init/src/blocks/custom/heading/heading-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { HeadingEditor } from './components/heading-editor';
 import { HeadingOptions } from './components/heading-options';

--- a/blocks/init/src/blocks/custom/image/image-block.js
+++ b/blocks/init/src/blocks/custom/image/image-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ImageEditor } from './components/image-editor';
 import { ImageOptions } from './components/image-options';

--- a/blocks/init/src/blocks/custom/jumbotron/jumbotron-block.js
+++ b/blocks/init/src/blocks/custom/jumbotron/jumbotron-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { InspectorControls } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { JumbotronEditor } from './components/jumbotron-editor';
 import { JumbotronOptions } from './components/jumbotron-options';

--- a/blocks/init/src/blocks/custom/link/link-block.js
+++ b/blocks/init/src/blocks/custom/link/link-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { LinkEditor } from './components/link-editor';
 import { LinkOptions } from './components/link-options';

--- a/blocks/init/src/blocks/custom/lists-info/lists-info-block.js
+++ b/blocks/init/src/blocks/custom/lists-info/lists-info-block.js
@@ -1,6 +1,6 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ListsInfoEditor } from './components/lists-info-editor';
 

--- a/blocks/init/src/blocks/custom/lists/lists-block.js
+++ b/blocks/init/src/blocks/custom/lists/lists-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ListsEditor } from './components/lists-editor';
 

--- a/blocks/init/src/blocks/custom/paragraph/paragraph-block.js
+++ b/blocks/init/src/blocks/custom/paragraph/paragraph-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { ParagraphEditor } from './components/paragraph-editor';
 import { ParagraphOptions } from './components/paragraph-options';

--- a/blocks/init/src/blocks/custom/quote/quote-block.js
+++ b/blocks/init/src/blocks/custom/quote/quote-block.js
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { QuoteEditor } from './components/quote-editor';
 

--- a/blocks/init/src/blocks/custom/video/video-block.js
+++ b/blocks/init/src/blocks/custom/video/video-block.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { VideoEditor } from './components/video-editor';
 import { VideoOptions } from './components/video-options';

--- a/blocks/init/src/blocks/wrapper/components/wrapper-options.js
+++ b/blocks/init/src/blocks/wrapper/components/wrapper-options.js
@@ -2,7 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody, TextControl, Dashicon, TabPanel, Icon } from '@wordpress/components';
-import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
+import { ColorPaletteCustom } from '@eightshift/frontend-libs';
 import { WrapperResponsiveTabContent } from './wrapper-responsive-tab-content';
 import globalSettings from '../../manifest.json';
 

--- a/blocks/init/src/blocks/wrapper/wrapper.js
+++ b/blocks/init/src/blocks/wrapper/wrapper.js
@@ -1,7 +1,7 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
-import { getActions } from 'EightshiftBlocksGetActions';
+import { getActions } from '@eightshift/frontend-libs';
 import manifest from './manifest.json';
 import { WrapperEditor } from './components/wrapper-editor';
 import { WrapperOptions } from './components/wrapper-options';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+export { ColorPaletteCustom } from './components/color-palette-custom/color-palette-custom';
+export { HeadingLevel } from './components/heading-level/heading-level';
+export { dynamicImport } from './scripts/dynamic-import';
+export { ucfirst } from './scripts/ucfirst';
+export { getActions } from './scripts/get-actions';
+export { media } from './scripts/helpers/media';
+export { cookies } from './scripts/helpers/cookies';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11587,8 +11587,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11606,13 +11605,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11625,18 +11622,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11739,8 +11733,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11750,7 +11743,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11763,20 +11755,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11793,7 +11782,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11874,8 +11862,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11885,7 +11872,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11961,8 +11947,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11992,7 +11977,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12010,7 +11994,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12049,13 +12032,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -161,5 +161,6 @@
     "jest": "^25.1.0",
     "replace-in-file": "^5.0.2",
     "sassdoc": "^2.7.1"
-  }
+  },
+  "module": "index.js"
 }

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+const { name } = require('../package.json');
 
 module.exports = (packagesPath) => {
   return {
@@ -12,7 +13,9 @@ module.exports = (packagesPath) => {
       alias: {
 
         // Alias this package for use when we're working on Storybook
-        '@eightshift/frontend-libs': path.resolve(packagesPath.libsPath),
+        // With this you can always import things from index.jx using:
+        // import { something } from '@eightshift/frontend-libs';
+        [name]: path.resolve(packagesPath.libsPath),
 
         // Node Modules.
         EightshiftBlocksWhatwgFetch: path.resolve(packagesPath.nodeModulesPath, 'whatwg-fetch'),

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -11,6 +11,9 @@ module.exports = (packagesPath) => {
     resolve: {
       alias: {
 
+        // Alias this package for use when we're working on Storybook
+        '@eightshift/frontend-libs': path.resolve(packagesPath.libsPath),
+
         // Node Modules.
         EightshiftBlocksWhatwgFetch: path.resolve(packagesPath.nodeModulesPath, 'whatwg-fetch'),
         EightshiftBlocksSwiper: path.resolve(packagesPath.nodeModulesPath, 'swiper'),

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -5,7 +5,6 @@
  */
 
 const path = require('path');
-const { name } = require('../package.json');
 
 module.exports = (packagesPath) => {
   return {
@@ -15,7 +14,7 @@ module.exports = (packagesPath) => {
         // Alias this package for use when we're working on Storybook
         // With this you can always import things from index.jx using:
         // import { something } from '@eightshift/frontend-libs';
-        [name]: path.resolve(packagesPath.libsPath),
+        '@eightshift/frontend-libs': path.resolve(packagesPath.libsPath),
 
         // Node Modules.
         EightshiftBlocksWhatwgFetch: path.resolve(packagesPath.nodeModulesPath, 'whatwg-fetch'),

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -12,7 +12,7 @@ module.exports = (packagesPath) => {
       alias: {
 
         // Alias this package for use when we're working on Storybook
-        // With this you can always import things from index.jx using:
+        // With this you can always import things from index.js using:
         // import { something } from '@eightshift/frontend-libs';
         '@eightshift/frontend-libs': path.resolve(packagesPath.libsPath),
 

--- a/webpack/aliases.js
+++ b/webpack/aliases.js
@@ -26,17 +26,27 @@ module.exports = (packagesPath) => {
         EightshiftBlocksMediaBlender: path.resolve(packagesPath.nodeModulesPath, 'media-blender'),
         EightshiftBlocksSwiperStyle: path.resolve(packagesPath.nodeModulesPath, 'swiper', 'swiper.scss'),
 
+        // Scss.
+        EightshiftFrontendLibs: path.resolve(packagesPath.libsPath, 'styles', 'scss', 'eightshift-frontend-libs.scss'),
+        EightshiftEditorStyleOverride: path.resolve(packagesPath.libsPath, 'styles', 'blocks', 'override-editor.scss'),
+
+        /**
+         * !!! DEPRECATED
+         *
+         * Please don't use the aliases below as they're only here for backwards-compatibility.
+         * Instead you can import them like this:
+         *
+         * Old: import { EightshiftBlocksDynamicImport } from 'EightshiftBlocksDynamicImport';
+         * New: import { EightshiftBlocksDynamicImport } from '@eightshift/frontend-libs';
+         */
+
         // Libs Paths Block Helpers.
         EightshiftBlocksDynamicImport: path.resolve(packagesPath.libsPath, 'scripts', 'dynamic-import'),
         EightshiftBlocksRegisterBlocks: path.resolve(packagesPath.libsPath, 'scripts', 'register-blocks'),
         EightshiftBlocksUcfirst: path.resolve(packagesPath.libsPath, 'scripts', 'ucfirst'),
         EightshiftBlocksGetActions: path.resolve(packagesPath.libsPath, 'scripts', 'get-actions'),
         EightshiftBlocksUtilityHelpersPath: path.resolve(packagesPath.libsPath, 'scripts', 'helpers'),
-
-        // Scss.
-        EightshiftFrontendLibs: path.resolve(packagesPath.libsPath, 'styles', 'scss', 'eightshift-frontend-libs.scss'),
-        EightshiftEditorStyleOverride: path.resolve(packagesPath.libsPath, 'styles', 'blocks', 'override-editor.scss'),
-
+        
         // Components.
         EightshiftComponentColorPalette: path.resolve(packagesPath.libsPath, 'components', 'color-palette-custom', 'color-palette-custom.js'),
         EightshiftComponentHeadingLevel: path.resolve(packagesPath.libsPath, 'components', 'heading-level', 'heading-level.js'),


### PR DESCRIPTION
To do
---
* [x] Test `npm run lintJs`
* [x] Test in Storybook context (working inside `frontend-libs` repository)
* [x] Test in project context (like in `eightshift-boilerplate` when `frontend-libs` in installed inside `node_modules`) - shouldn't be any issues tho (_unless alias clashes with normal module import_)
* [ ] Test in local Storybook (building a Storybook inside your project) - should be the same as the project context one 
* [ ] More research to see if this can be done for other aliases (specifically `.scss` ones and those from `node_modules`) - those are a bit tricky because (especially ones from `node_modules`) because their paths vary depending on if we're in the context of a project (like Eightshift Boilerplate) or in the context of Storybook (working from inside `frontend-libs` repository) - already tried a bunch of things for this but with little luck

Changelog
---
* Replaced some aliases with import from module (for example: `import { ColorPaletteCustom } from '@eightshift/frontend-libs`, instead of `import { ColorPaletteCustom } from 'EightshiftComponentColorPalette`)
  - Had to build an alias for `@eightshift/frontend-libs` in order for this to work while we're working on Storybook from inside the `frontend-libs` repp
