### PR TITLE
Editor color pallete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 * Added `page-overlay` to block copying.
+* `editor-color-pallete` - Modified the `ColorPaletteCustom` component to get colors by default from WordPress's global store
+* `editor-color-pallete` - Modified all uses of `ColorPaletteCustom` component to not override default colors (except for wrapper)
+* `editor-color-pallete` - Added a helper (using React hooks) for reading colors from WordPress's global store.
+* Added docs for `editor-color-pallete`
 
 ### [Tweak header components PR]
 * Added support for `behind` and `top` drawers / mobile menus (slide from top or fade in)

--- a/blocks/init/src/blocks/components/button/components/button-options.js
+++ b/blocks/init/src/blocks/components/button/components/button-options.js
@@ -4,7 +4,6 @@ import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/block-editor';
 import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, TextControl, Icon, BaseControl } from '@wordpress/components';
-import globalSettings from './../../../manifest.json';
 
 export const ButtonOptions = (props) => {
   const {
@@ -53,10 +52,6 @@ export const ButtonOptions = (props) => {
             </Fragment>
           }
           help={__('Change Button Background color.', 'eightshift-boilerplate')}
-          colors={[
-            globalSettings.colors.primary,
-            globalSettings.colors.black,
-          ]}
           value={styleColor}
           onChange={onChangeStyleColor}
         />

--- a/blocks/init/src/blocks/components/heading/components/heading-options.js
+++ b/blocks/init/src/blocks/components/heading/components/heading-options.js
@@ -3,7 +3,6 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, Icon } from '@wordpress/components';
-import globalSettings from './../../../manifest.json';
 
 export const HeadingOptions = (props) => {
   const {
@@ -27,10 +26,6 @@ export const HeadingOptions = (props) => {
             </Fragment>
           }
           help={__('Change Heading color.', 'eightshift-boilerplate')}
-          colors={[
-            globalSettings.colors.primary,
-            globalSettings.colors.black,
-          ]}
           value={styleColor}
           onChange={onChangeStyleColor}
         />

--- a/blocks/init/src/blocks/components/link/components/link-options.js
+++ b/blocks/init/src/blocks/components/link/components/link-options.js
@@ -4,7 +4,6 @@ import { Fragment } from '@wordpress/element';
 import { URLInput } from '@wordpress/block-editor';
 import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { ToggleControl, Icon, BaseControl } from '@wordpress/components';
-import globalSettings from './../../../manifest.json';
 
 export const LinkOptions = (props) => {
   const {
@@ -30,10 +29,6 @@ export const LinkOptions = (props) => {
             </Fragment>
           }
           help={__('Change Link color.', 'eightshift-boilerplate')}
-          colors={[
-            globalSettings.colors.primary,
-            globalSettings.colors.black,
-          ]}
           value={styleColor}
           onChange={onChangeStyleColor}
         />

--- a/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
+++ b/blocks/init/src/blocks/components/paragraph/components/paragraph-options.js
@@ -3,7 +3,6 @@ import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
 import { SelectControl, Icon } from '@wordpress/components';
-import globalSettings from './../../../manifest.json';
 
 export const ParagraphOptions = (props) => {
   const {
@@ -30,10 +29,6 @@ export const ParagraphOptions = (props) => {
                 </Fragment>
               }
               help={__('Change Paragraph color.', 'eightshift-boilerplate')}
-              colors={[
-                globalSettings.colors.primary,
-                globalSettings.colors.black,
-              ]}
               value={styleColor}
               onChange={onChangeStyleColor}
             />

--- a/blocks/init/src/blocks/custom/divider/components/divider-options.js
+++ b/blocks/init/src/blocks/custom/divider/components/divider-options.js
@@ -2,7 +2,6 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { ColorPaletteCustom } from 'EightshiftComponentColorPalette';
-import globalSettings from './../../../manifest.json';
 
 export const DividerOptions = (props) => {
   const {
@@ -20,11 +19,6 @@ export const DividerOptions = (props) => {
       {onChangeColor &&
         <ColorPaletteCustom
           label={__('Color', 'eightshift-boilerplate')}
-          colors={[
-            globalSettings.colors.primary,
-            globalSettings.colors.black,
-            globalSettings.colors.white,
-          ]}
           value={color}
           onChange={onChangeColor}
         />

--- a/components/color-palette-custom/docs/readme.md
+++ b/components/color-palette-custom/docs/readme.md
@@ -1,1 +1,54 @@
 # Color Palette Custom
+
+This is a slightly modified version of ColorPallete (from @wordpress/components) which saves color's slug (or name if slug not provided) rather than color's hex (which is the default behavior).
+
+The reasoning is that this way we can add color names as class modifiers to blocks and then style those blocks in CSS / SCSS (rather than having to inline colors as with the default ColorPallete component).
+
+By default it uses the default editor pallete (see https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes) but you can override the colors for particular blocks by passing your own `colors` prop.
+
+## Example #1 - Default
+
+```jsx
+<ColorPaletteCustom
+  label={'Block Color'}
+  help={'Change block color'}
+  value={styleColor}
+  onChange={onChangeStyleColor}
+/>
+```
+
+### Example #2 - Override colors using some of the editor-color-pallete colors
+```jsx
+import { getPalleteColors } from '@eightshift/frontend-libs';
+
+const {
+  color1,
+  color2
+} = getPalleteColors();
+
+<ColorPaletteCustom
+  label={'Block Color'}
+  help={'Change block color'}
+  value={styleColor}
+  onChange={onChangeStyleColor}
+  colors={[color1, color2]}
+/>
+```
+
+### Example #3 - Override colors using custom colors not in editor pallete
+```jsx
+
+const specificColor = {
+  name: 'Specific',
+  slug: 'specific',
+  color: '#FF11BB'
+};
+
+<ColorPaletteCustom
+  label={'Block Color'}
+  help={'Change block color'}
+  value={styleColor}
+  onChange={onChangeStyleColor}
+  colors={[specificColor]}
+/>
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export { getPalleteColors } from './scripts/get-pallete-colors';

--- a/scripts/get-pallete-colors.js
+++ b/scripts/get-pallete-colors.js
@@ -1,0 +1,17 @@
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Use this hook to read editor-color-pallete colors directly from WP's built in store.
+ *
+ * Requires WP => 5.3
+ */
+export const getPalleteColors = () => useSelect((select) => {
+  const settings = select('core/block-editor').getSettings();
+  return settings.colors.reduce(
+    (obj, item) => ({
+      ...obj,
+      [item.slug]: item,
+    }),
+    {}
+  );
+});


### PR DESCRIPTION
Changelog
---
* `editor-color-pallete` - Modified the `ColorPaletteCustom` component to get colors by default from WordPress's global store
* `editor-color-pallete` - Modified all uses of `ColorPaletteCustom` component to not override default colors (except for wrapper)
* `editor-color-pallete` - Added a helper (using React hooks) for reading colors from WordPress's global store in `scripts/get-pallete-colors.js`
* Added docs for `editor-color-pallete`

These changes are backwards compatible with existing blocks setting colors "the old way" and nothing should break if you were to update libs on an existing project.

Also instead of using `useSelect` (which isn't supported on WP < 5.3), I've used `withSelect` HOC on `ColorPaletteCustom` which should work everywhere. There's a helper which uses `useSelect` to read colors from WP's global store for when you need to override colors on specific components (but still want to use some of editor-color-pallete colors).

This needs to be merged AFTER PR on `libs` adding editor color pallete - https://github.com/infinum/eightshift-libs/pull/50

_@iruzevic for some reason the `components/color-palette-custom` & `components/heading-level` don't seem to be showing in Storybook, do you happen to know why this is the case?_