### PR TITLE
Import absolute-center placeholder.

### DIFF
--- a/styles/scss/placeholders/_all.scss
+++ b/styles/scss/placeholders/_all.scss
@@ -1,4 +1,5 @@
 // Init all Placeholders.
+@import 'absolute-center';
 @import 'bg-image';
 @import 'button';
 @import 'clearfix';


### PR DESCRIPTION
`absolute-center` placeholder was added (and it's in sassdoc) but wasn't imported.