### PR TITLE
Add icons to columns

### DIFF
--- a/blocks/init/src/blocks/custom/column/manifest.json
+++ b/blocks/init/src/blocks/custom/column/manifest.json
@@ -3,6 +3,9 @@
   "title": "Column",
   "description" : "Column block with custom settings.",
   "category": "eightshift",
+  "icon": {
+    "src": "controls-pause"
+  },
   "keywords": [
     "column"
   ],

--- a/blocks/init/src/blocks/custom/columns/manifest.json
+++ b/blocks/init/src/blocks/custom/columns/manifest.json
@@ -3,6 +3,9 @@
   "title": "Columns",
   "description" : "Columns block with custom settings.",
   "category": "eightshift",
+  "icon": {
+    "src": "controls-pause"
+  },
   "keywords": [
     "columns"
   ],


### PR DESCRIPTION
Without `icon` property in `manifest.json`, columns block throws the following error when used in a project.

We can change what the actual icon is tho.

```
applicationBlocksEditor.js?ver=1.0.0:1402 Uncaught TypeError: Cannot read property 'background' of undefined
    at registerBlock (applicationBlocksEditor.js?ver=1.0.0:1402)
    at applicationBlocksEditor.js?ver=1.0.0:1551
    at Array.map (<anonymous>)
    at registerBlocks (applicationBlocksEditor.js?ver=1.0.0:1525)
    at Module../src/blocks/assets/scripts/application-blocks-editor.js (applicationBlocksEditor.js?ver=1.0.0:11023)
    at __webpack_require__ (applicationBlocksEditor.js?ver=1.0.0:20)
    at Module../src/blocks/assets/application-blocks-editor.js (applicationBlocksEditor.js?ver=1.0.0:10975)
    at __webpack_require__ (applicationBlocksEditor.js?ver=1.0.0:20)
    at applicationBlocksEditor.js?ver=1.0.0:84
    at applicationBlocksEditor.js?ver=1.0.0:87
```