### PR TITLE
Copy carousel block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+- Copy Carousel during setup so Image block doesn't throw errors during build time (because of image-transform.js which is expecting Carousel Image)
+
 ## [3.5.0] - 2020-06-03
 
 ### Added

--- a/setup/create-wp-project/package.json
+++ b/setup/create-wp-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-wp-project",
   "description": "This is a setup script for creating a WordPress project.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Team Eightshift",
   "main": "",
   "license": "MIT",

--- a/setup/create-wp-project/src/blocks.js
+++ b/setup/create-wp-project/src/blocks.js
@@ -19,6 +19,7 @@ const componentsToCopy = [
   'hamburger',
   'copyright',
   'page-overlay',
+  'carousel-navigation',
 ];
 
 const blocksToCopy = [
@@ -30,6 +31,8 @@ const blocksToCopy = [
   'paragraph',
   'video',
   'example',
+  'carousel',
+  'carousel-image',
 ];
 
 /**


### PR DESCRIPTION
Fixes #159 by copying carousel block (and related components) during setup. I've already published the setup script so we don't have a broken boilerplate during the weeked.

If we don't wish to copy Carousel during setup, we can remove the file that caused the issue `image-transforms.js` and remove Carousel block from setup.