### PR TITLE
Add visually hidden placeholder to all.scss

### DIFF
--- a/styles/scss/placeholders/_all.scss
+++ b/styles/scss/placeholders/_all.scss
@@ -11,3 +11,4 @@
 @import 'paragraph';
 @import 'site-padding-correction';
 @import 'site-padding';
+@import 'visually-hidden';


### PR DESCRIPTION
`%visually-hidden` placeholder wasn't added to `_all.scss`