### PR TITLE
Add relative helpers for line height and em calculation

### DIFF
--- a/styles/scss/functions/_all.scss
+++ b/styles/scss/functions/_all.scss
@@ -6,3 +6,5 @@
 @import 'map-get-deep';
 @import 'map-get-strict';
 @import 'map-reverse';
+@import 'em';
+@import 'line-height';

--- a/styles/scss/functions/_em.scss
+++ b/styles/scss/functions/_em.scss
@@ -1,0 +1,43 @@
+/// Transforms the pixel value to em value.
+///
+/// If context is not provided, it will be pulled from the $base-font-size.
+///
+/// ### Output
+/// ```scss
+/// .test {
+///   font-size: 20px;
+///
+///   &__subelement {
+///      font-size: 0.5em;
+///   }
+///
+///   &__second-subelement {
+///      font-size: 0.25em;
+///   }
+/// }
+/// ```
+///
+/// @access public
+/// @author Denis Zoljom
+/// @param {Number} $pixels The pixel value that should be converted to em. Needs to be specified without px.
+/// @param {Number} $context The relative context. Defaults to relative element with font-size defined.
+///
+/// @example
+/// .test {
+///   font-size: 20px;
+///
+///   &__subelement {
+///      font-size: em(10); // Will be 0.5em.
+///   }
+///
+///   &__second-subelement {
+///      font-size: em(10, 40); // Will be 0.25em.
+///   }
+/// }
+///
+
+$browser-context: $base-font-size;
+
+@function em($pixels, $context: $browser-context) {
+	@return #{$pixels/$context}em;
+}

--- a/styles/scss/functions/_line-height.scss
+++ b/styles/scss/functions/_line-height.scss
@@ -1,0 +1,46 @@
+/// Transforms the line-height to relative value.
+///
+/// If context is not provided, it will be pulled from the $base-font-size.
+/// Line height will be specified without any unit.
+///
+/// ### Output
+/// ```scss
+///
+/// // $base-font-size = 20.
+///
+/// .test {
+///   &__subelement {
+///      line-height: 1;
+///   }
+///
+///   &__second-subelement {
+///      line-height: 1.19;
+///   }
+/// }
+/// ```
+///
+/// @access public
+/// @author Denis Zoljom
+/// @param {Number} $pixels The pixel value that should be converted to relative value. Needs to be specified without px.
+/// @param {Number} $context The relative context. Defaults to $base-font-size.
+///
+/// @example
+/// .test {
+///   font-size: 20px;
+///
+///   &__subelement {
+///      font-size: line-height(20);
+///   }
+///
+///   &__second-subelement {
+///      font-size: line-height(38, 32);
+///   }
+/// }
+///
+
+$browser-context: $base-font-size;
+
+// Calculate line-height in relative units from pixels.
+@function line-height($pixels, $context: $browser-context) {
+	@return #{$pixels/$context};
+}


### PR DESCRIPTION
As the title suggests. Takes the value that should be in pixels, and converts it to em. 

Using ems is cool because when you zoom the site, everything scales up quite nicely 🙂 