### PR TITLE
Fix attribute type

### DIFF
--- a/blocks/init/src/Blocks/components/heading/manifest.json
+++ b/blocks/init/src/Blocks/components/heading/manifest.json
@@ -17,7 +17,7 @@
 			"type": "string"
 		},
 		"headingLevel": {
-			"type": "int",
+			"type": "integer",
 			"default": 2
 		},
 		"headingSize": {

--- a/blocks/init/src/Blocks/custom/column/manifest.json
+++ b/blocks/init/src/Blocks/custom/column/manifest.json
@@ -35,30 +35,30 @@
 			"default": true
 		},
 		"widthLarge": {
-			"type": "int",
+			"type": "integer",
 			"default": 4
 		},
 		"widthDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"widthTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"widthMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"offsetLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"offsetDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"offsetTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"offsetMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"hideLarge": {
@@ -75,16 +75,16 @@
 		},
 
 		"orderLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"orderDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"orderTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"orderMobile": {
-			"type": "int"
+			"type": "integer"
 		}
 	},
 	"options": {

--- a/blocks/init/src/Blocks/custom/columns/manifest.json
+++ b/blocks/init/src/Blocks/custom/columns/manifest.json
@@ -81,31 +81,31 @@
 		},
 
 		"gutterLarge": {
-			"type": "int",
+			"type": "integer",
 			"default": 30
 		},
 		"gutterDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"gutterTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"gutterMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"verticalSpacingLarge": {
-			"type": "int",
+			"type": "integer",
 			"default": 30
 		},
 		"verticalSpacingDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"verticalSpacingTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"verticalSpacingMobile": {
-			"type": "int"
+			"type": "integer"
 		}
 	},
 	"options": {

--- a/blocks/init/src/Blocks/wrapper/manifest.json
+++ b/blocks/init/src/Blocks/wrapper/manifest.json
@@ -12,7 +12,7 @@
 			"wrapperUseSimpleShowControl": true,
 			"wrapperDisable": false,
 			"wrapperParentClass": "",
-	
+
 			"wrapperWidthLarge": 12,
 			"wrapperWidthDesktop": 6,
 			"wrapperWidthTablet": 3,
@@ -66,30 +66,30 @@
 		},
 
 		"wrapperWidthLarge": {
-			"type": "int",
+			"type": "integer",
 			"default": 12
 		},
 		"wrapperWidthDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperWidthTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperWidthMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperOffsetLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperOffsetDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperOffsetTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperOffsetMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperContainerWidthLarge": {
@@ -121,56 +121,56 @@
 		},
 
 		"wrapperSpacingTopLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperSpacingBottomLarge": {
-			"type": "int",
+			"type": "integer",
 			"default": 40
 		},
 		"wrapperSpacingBottomDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingBottomTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingBottomMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperSpacingTopInLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopInDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopInTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingTopInMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperSpacingBottomInLarge": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingBottomInDesktop": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingBottomInTablet": {
-			"type": "int"
+			"type": "integer"
 		},
 		"wrapperSpacingBottomInMobile": {
-			"type": "int"
+			"type": "integer"
 		},
 
 		"wrapperDividerTopLarge": {


### PR DESCRIPTION
We had incorrect attribute type for all numeric attributes, which produced errors when attribute was changed.

This happens on fresh BP installation, installed with:
`npx create-wp-project --eightshiftBoilerplateBranch="release/5.0.0"`

```
PHP Notice:  rest_validate_value_from_schema was called <strong>incorrectly</strong>. The "type" schema keyword for  can only be one of the built-in types: array, object, string, number, integer, boolean, and null.
```
Can someone please double check this before this is merged.

<img width="416" alt="Screenshot at Dec 07 22-38-50" src="https://user-images.githubusercontent.com/41635034/101409072-9eea1180-38dd-11eb-869b-c45db92a80e5.png">
