### PR TITLE
Fix path to the blocks folder for standalone Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react';
 import { storybookWindowObjects, storybookDefaultMocksCategories, storybookDefaultMocksColorPalette, storybookWpStyles } from './../scripts/storybook';
-import globalSettings from './../blocks/init/src/Blocks/manifest.json';
+import globalSettings from './../blocks/init/src/blocks/manifest.json';
 
 // Storybook import order is really important because it won't work in any configuration. Be careful when changing stuff here.
 
@@ -9,10 +9,10 @@ storybookWindowObjects();
 
 // Run all storybook stories.
 configure([
-	require.context('./../blocks/init/src/Blocks/components', true, /docs\/story.js$/),
-	require.context('./../blocks/init/src/Blocks/custom', true, /docs\/story.js$/),
-	require.context('./../blocks/init/src/Blocks/wrapper', true, /docs\/story.js$/),
-	require.context('./../blocks/init/src/Blocks/variations', true, /docs\/story.js$/),
+	require.context('./../blocks/init/src/blocks/components', true, /docs\/story.js$/),
+	require.context('./../blocks/init/src/blocks/custom', true, /docs\/story.js$/),
+	require.context('./../blocks/init/src/blocks/wrapper', true, /docs\/story.js$/),
+	require.context('./../blocks/init/src/blocks/variations', true, /docs\/story.js$/),
 	require.context('./../scripts/components', true, /docs\/story.js$/),
 ], module);
 
@@ -28,9 +28,9 @@ storybookWpStyles();
 // Project styles.
 require('./../blocks/init/assets/styles/application.scss');
 
-// Project Blocks Frontend Part.
-require('./../blocks/init/src/Blocks/assets/styles/application-blocks.scss');
-require('./../blocks/init/src/Blocks/assets/styles/application-blocks-editor.scss');
+// Project blocks Frontend Part.
+require('./../blocks/init/src/blocks/assets/styles/application-blocks.scss');
+require('./../blocks/init/src/blocks/assets/styles/application-blocks-editor.scss');
 
-// Project Blocks Editor Part.
-require('./../blocks/init/src/Blocks/assets/scripts/application-blocks-editor');
+// Project blocks Editor Part.
+require('./../blocks/init/src/blocks/assets/scripts/application-blocks-editor');


### PR DESCRIPTION
The path to blocks folder was same as for the Storybook setup in boilerplate, which is different for standalone Storybook setup.