### PR TITLE
Create _strip-unit.scss

### DIFF
--- a/styles/scss/functions/_all.scss
+++ b/styles/scss/functions/_all.scss
@@ -6,5 +6,6 @@
 @import 'map-get-deep';
 @import 'map-get-strict';
 @import 'map-reverse';
+@import 'strip-unit';
 @import 'em';
 @import 'line-height';

--- a/styles/scss/functions/_strip-unit.scss
+++ b/styles/scss/functions/_strip-unit.scss
@@ -1,0 +1,22 @@
+/// Strips the unit from the passed value
+///
+/// If context is not provided, it will be pulled from the $base-font-size.
+///
+/// ### Output
+/// ```scss
+/// $width: 960px;
+/// $unitless-width: strip-unit($width); // 960
+/// ```
+///
+/// @access public
+/// @author https://css-tricks.com/snippets/sass/strip-unit-function/
+/// @param {Number} $number The number to remove unit from.
+///
+
+@function strip-unit($number) {
+  @if type-of($number) == 'number' and not unitless($number) {
+    @return $number / ($number * 0 + 1);
+  }
+
+  @return $number;
+}

--- a/styles/scss/functions/_strip-unit.scss
+++ b/styles/scss/functions/_strip-unit.scss
@@ -1,7 +1,5 @@
 /// Strips the unit from the passed value
 ///
-/// If context is not provided, it will be pulled from the $base-font-size.
-///
 /// ### Output
 /// ```scss
 /// $width: 960px;


### PR DESCRIPTION
Add a strip unit helper that will be used for the calculation of the relative units. With this helper, we can pass numbers with units (e.g `20px`) or without, when calculating relative values (those will have to be changed of course). That way we can reuse things from `manifest.json`.