### PR TITLE
Accordion component update

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -24,7 +24,7 @@ $accordionTitle = Components::checkAttr('accordionTitle', $attributes, $manifest
 $accordionContent = Components::checkAttr('accordionContent', $attributes, $manifest, $componentName);
 $accordionIsOpen = Components::checkAttr('accordionIsOpen', $attributes, $manifest, $componentName);
 
-$componentJsClass = Components::selector($componentClass, $componentClass, "js-{$componentClass}");
+$componentJsClass = Components::selector($componentClass, "js-{$componentClass}");
 
 $accordionClass = Components::classnames([
 	$componentClass,

--- a/blocks/init/src/Blocks/components/accordion/assets/accordion.js
+++ b/blocks/init/src/Blocks/components/accordion/assets/accordion.js
@@ -1,3 +1,5 @@
+import { elementChildrenHeight } from '@eightshift/frontend-libs/scripts/helpers';
+
 export class Accordion {
 	constructor(options) {
 		this.accordion = options.accordion;
@@ -7,7 +9,7 @@ export class Accordion {
 		this.panelSelector = `${options.accordionSelector}-panel`;
 
 		this.trigger = this.accordion.querySelectorAll(this.triggerSelector);
-		
+
 		this.ATTR_HIDDEN = 'aria-hidden';
 		this.ATTR_OPEN = 'data-accordion-open';
 		this.ATTR_PREVENT_CLOSE = 'data-accordion-prevent-close';
@@ -41,6 +43,7 @@ export class Accordion {
 
 		[...panels].forEach((panel) => {
 			panel.setAttribute(this.ATTR_HIDDEN, 'true');
+			panel.style.maxHeight = '';
 		});
 	}
 
@@ -51,11 +54,13 @@ export class Accordion {
 	close(item, panel) {
 		item.setAttribute(this.ATTR_OPEN, 'false');
 		panel.setAttribute(this.ATTR_HIDDEN, 'true');
+		panel.style.maxHeight = '';
 	}
 
 	open(item, panel) {
 		item.setAttribute(this.ATTR_OPEN, 'true');
 		panel.setAttribute(this.ATTR_HIDDEN, 'false');
+		panel.style.maxHeight = `${elementChildrenHeight(panel)}px`;
 	}
 
 }

--- a/scripts/helpers/element-children-height.js
+++ b/scripts/helpers/element-children-height.js
@@ -1,0 +1,15 @@
+/**
+ * Returns height of the element measured by height of its children.
+ *
+ * @param object element DOM element
+ *
+ * @return Combined height of the children elements
+ */
+export function elementChildrenHeight(element) {
+	let height = 0;
+	[...element.children].forEach((child) => {
+		height += child.offsetHeight;
+	});
+
+	return height;
+}

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -7,3 +7,4 @@ export { getNavigatorVibrate } from './navigator';
 export { responsiveSelectors } from './responsive-selectors';
 export { selector } from './selector';
 export { checkAttr } from './check-attr';
+export { elementChildrenHeight } from './element-children-height';


### PR DESCRIPTION
Add a helper method for calculating height of the element based on the combined height of its children.

Update accordion functionality to expand the accordion content by the correct height (instead of fixed one).

Fix accordion JS class

![image](https://user-images.githubusercontent.com/41635034/102111675-fedd3c80-3e36-11eb-9fed-876b88bf8a9c.png)
