### PR TITLE
Replace bloginfo() with get_bloginfo()

### DIFF
--- a/blocks/init/src/Blocks/components/head/head.php
+++ b/blocks/init/src/Blocks/components/head/head.php
@@ -7,8 +7,8 @@
  */
 
 $icon = $attributes['icon'] ?? '';
-$charset = $attributes['charset'] ?? \bloginfo('charset');
-$name = $attributes['name'] ?? \bloginfo('name');
+$charset = $attributes['charset'] ?? \get_bloginfo('charset');
+$name = $attributes['name'] ?? \get_bloginfo('name');
 ?>
 
 <meta charset="<?php echo \esc_attr($charset); ?>" />


### PR DESCRIPTION
`bloginfo()` echoes the value. When you try to echoe it again inside the meta element, the whole `<head>` breaks.
`get_bloginfo()` returns the value.