### PR TITLE
Add inline font color mixin

### DIFF
--- a/styles/scss/mixins/_all.scss
+++ b/styles/scss/mixins/_all.scss
@@ -27,3 +27,4 @@
 @import 'for-each-attribute';
 @import 'underline-text';
 @import 'underline';
+@import 'inline-font-colors';

--- a/styles/scss/mixins/_inline-font-colors.scss
+++ b/styles/scss/mixins/_inline-font-colors.scss
@@ -1,0 +1,36 @@
+/// Mixin that will create a Gutenberg specific inline color class. This enables coloring parts of the words.
+///
+/// @access public
+/// @author Denis Žoljom
+///
+/// @param {map} $colors [] Map of the colors that need to be passed.
+///
+/// @example
+///   $heading: (
+///       colors: (
+///          primary: global-settings(colors, primary),
+///          gulf: global-settings(colors, gulf),
+///       )
+///   );
+///
+///   .heading {
+///       @include inline-font-colors(map-get-strict($heading, colors));
+///   }
+///
+/// @output
+/// ```scss
+///   .heading .has-primary-color {
+///       color: #011751;
+///   }
+///   .heading .has-gulf-color {
+///       color: #FFC660;
+///   }
+/// ```
+
+@mixin inline-font-colors($colors) {
+  @each $colorName, $colorValue in $colors {
+    .has-#{$colorName}-color {
+      color: $colorValue;
+    }
+  }
+}


### PR DESCRIPTION
There is an option in the `RichText` component to add several different toolbars to it. One of them is the `text-color`

```js
<RichText
	className={headingClass}
	placeholder={placeholder}
	value={headingContent}
	onChange={(value) => setAttributes({ [`${componentName}Content`]: value })}
	formattingControls={['bold', 'text-color']}
/>
```

This will give you the ability to color certain parts of the word in the component. For instance, for the heading component this will look like this:

![Screenshot 2021-01-07 at 11 18 50](https://user-images.githubusercontent.com/8638515/103881002-2643c400-50da-11eb-903d-6ff41d84b353.png)

Based on what colors you specify in your component map, you can pass this map to the mixin and it will automatically generate the necessary predefined Gutenberg classes (`.has-{colorName}-color` format).
