### PR TITLE
Add browser sync to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"autoprefixer": "^9.8.6",
 		"babel-eslint": "^10.1.0",
 		"babel-loader": "^8.2.2",
+		"browser-sync": "^2.26.13",
 		"browser-sync-webpack-plugin": "^2.3.0",
 		"classnames": "^2.2.6",
 		"clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
Added missing `browser-sync` package to `package.json` because of dependency for the `browser-sync-webpack-plugin` package.