### PR TITLE
updating Webpack externals

### DIFF
--- a/babel/babel.config.js
+++ b/babel/babel.config.js
@@ -10,5 +10,11 @@ module.exports = {
 				useBuiltIns: true,
 			},
 		],
+		[
+			"@babel/plugin-proposal-class-properties",
+			{
+				"loose": true
+			}
+		]
 	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@infinumjs/eslint-config-react-js": "^2.2.0",
 				"@wordpress/babel-preset-default": "^4.20.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",
+				"@wordpress/dom-ready": "^2.11.0",
 				"@wordpress/icons": "^2.8.0",
 				"autoprefixer": "^9.8.6",
 				"babel-eslint": "^10.1.0",
@@ -7576,7 +7577,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.11.0.tgz",
 			"integrity": "sha512-q9MZqYPHUtioT/2tgzyAtnEFXRgUJ6eMxLDQaOprBQkGoD2Ue/V+wEX6cJGy+x8AafFataPC2i2jPsnYqE9+zQ==",
-			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.11.2"
 			}
@@ -45970,7 +45970,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.11.0.tgz",
 			"integrity": "sha512-q9MZqYPHUtioT/2tgzyAtnEFXRgUJ6eMxLDQaOprBQkGoD2Ue/V+wEX6cJGy+x8AafFataPC2i2jPsnYqE9+zQ==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.11.2"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"husky": "^4.3.6",
 				"import-glob-loader": "^1.1.0",
 				"media-blender": "^2.1.0",
+				"micromodal": "^0.4.6",
 				"mini-css-extract-plugin": "^1.3.3",
 				"node-sass": "^5.0.0",
 				"normalize-scss": "^7.0.1",
@@ -24352,6 +24353,14 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/micromodal": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.6.tgz",
+			"integrity": "sha512-2VDso2a22jWPpqwuWT/4RomVpoU3Bl9qF9D01xzwlNp5UVsImeA0gY4nSpF44vqcQtQOtkiMUV9EZkAJSRxBsg==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/miller-rabin": {
@@ -59456,6 +59465,11 @@
 					}
 				}
 			}
+		},
+		"micromodal": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.6.tgz",
+			"integrity": "sha512-2VDso2a22jWPpqwuWT/4RomVpoU3Bl9qF9D01xzwlNp5UVsImeA0gY4nSpF44vqcQtQOtkiMUV9EZkAJSRxBsg=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/cli": "^7.12.10",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/polyfill": "^7.12.1",
 				"@infinumjs/eslint-config-react-js": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"husky": "^4.3.6",
 		"import-glob-loader": "^1.1.0",
 		"media-blender": "^2.1.0",
+		"micromodal": "^0.4.6",
 		"mini-css-extract-plugin": "^1.3.3",
 		"node-sass": "^5.0.0",
 		"normalize-scss": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"@infinumjs/eslint-config-react-js": "^2.2.0",
 		"@wordpress/babel-preset-default": "^4.20.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",
+		"@wordpress/dom-ready": "^2.11.0",
 		"@wordpress/icons": "^2.8.0",
 		"autoprefixer": "^9.8.6",
 		"babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@babel/cli": "^7.12.10",
+		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 		"@babel/polyfill": "^7.12.1",
 		"@infinumjs/eslint-config-react-js": "^2.2.0",

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -46,7 +46,13 @@ module.exports = (options) => {
 
 	// Enable export for all WordPress related packages
 	if (!options.overrides.includes('DependencyExtractionWebpackPlugin')) {
-		plugins.push(new DependencyExtractionWebpackPlugin());
+		plugins.push(new DependencyExtractionWebpackPlugin({
+			requestToExternal: function ( request ) {
+				if ( request === '@wordpress/dom-ready' ) {
+					return '';
+				}
+			}
+		}));
 	}
 
 	// All Optimizations used in production and development build.


### PR DESCRIPTION
- without this fix the DependencyExtractionWebpackPlugin will put everything with @wordpress prefix as a global and we don't want that on the frontend