### PR TITLE
Fix onChange property for videoType attribute.

### DIFF
--- a/blocks/init/src/Blocks/components/video/components/video-options.js
+++ b/blocks/init/src/Blocks/components/video/components/video-options.js
@@ -79,10 +79,8 @@ export const VideoOptions = (attributes) => {
 							label={__('Type', 'eightshift-frontend-libs')}
 							value={videoType}
 							options={options.types}
-							onChange={(value) => setAttributes({
-								[`${componentName}type`]: value,
-								[`${componentName}Url`]: '',
-							})}
+							onChange={(value) => setAttributes({ [`${componentName}Type`]: value })}
+							help={__('If you want to use local video, you must remove the URL', 'eightshift-frontend-libs')}
 						/>
 					}
 


### PR DESCRIPTION
Fix typo in `videoType` attribute name
Add `help` property to the `videoType` select component
Remove `videoUrl` from `onChange` method of  `videoType` select component
