### PR TITLE
make offset on Columns settable to 0

### DIFF
--- a/blocks/init/src/Blocks/custom/column/components/column-options.js
+++ b/blocks/init/src/Blocks/custom/column/components/column-options.js
@@ -98,9 +98,9 @@ export const ColumnOptions = ({ attributes, setAttributes }) => {
 								allowReset={true}
 								value={attributes[attr]}
 								onChange={(value) => setAttributes({ [attr]: value })}
-								min={options.widths.min}
-								max={options.widths.max}
-								step={options.widths.step}
+								min={options.offsets.min}
+								max={options.offsets.max}
+								step={options.offsets.step}
 								resetFallbackValue={reset[attr].default}
 							/>
 						</Fragment>

--- a/blocks/init/src/Blocks/custom/column/manifest.json
+++ b/blocks/init/src/Blocks/custom/column/manifest.json
@@ -103,6 +103,11 @@
 			"max":  12,
 			"step": 1
 		},
+		"offsets": {
+			"min": 0,
+			"max": 12,
+			"step": 1
+		},
 		"orders": {
 			"min":  1,
 			"max":  20,


### PR DESCRIPTION
The `Offset` property on column was not settable to `0`, which can sometimes be inconvenient, eg. when doing responsive offsets.

This PR adds a new entry into the manifest options and makes the Offset's RangeControl use min/max/step from that new entry.