### PR TITLE
Fix order value not being applied on Columns

### DIFF
--- a/blocks/init/src/Blocks/custom/column/column.php
+++ b/blocks/init/src/Blocks/custom/column/column.php
@@ -45,7 +45,7 @@ $componentClass = Components::classnames([
 	Components::responsiveSelectors($width, 'width', $blockClass),
 	Components::responsiveSelectors($offset, 'offset', $blockClass),
 	Components::responsiveSelectors($hide, 'hide', $blockClass, false),
-	Components::responsiveSelectors($order, 'order', $blockClass, false),
+	Components::responsiveSelectors($order, 'order', $blockClass),
 ]);
 ?>
 

--- a/blocks/init/src/Blocks/custom/column/components/column-options.js
+++ b/blocks/init/src/Blocks/custom/column/components/column-options.js
@@ -98,9 +98,9 @@ export const ColumnOptions = ({ attributes, setAttributes }) => {
 								allowReset={true}
 								value={attributes[attr]}
 								onChange={(value) => setAttributes({ [attr]: value })}
-								min={options.widths.min}
-								max={options.widths.max}
-								step={options.widths.step}
+								min={options.offsets.min}
+								max={options.offsets.max}
+								step={options.offsets.step}
 								resetFallbackValue={reset[attr].default}
 							/>
 						</Fragment>

--- a/blocks/init/src/Blocks/custom/column/manifest.json
+++ b/blocks/init/src/Blocks/custom/column/manifest.json
@@ -103,6 +103,11 @@
 			"max":  12,
 			"step": 1
 		},
+		"offsets": {
+			"min": 0,
+			"max": 12,
+			"step": 1
+		},
 		"orders": {
 			"min":  1,
 			"max":  20,


### PR DESCRIPTION
The `order` property in the column options is saved properly, but because the Responsive selectors in `columns.php` were set **not** to use modifiers, the actual value wasn't being reflected in the outputted classes.