### PR TITLE
fix vertical spacing not being applied on Columns

### DIFF
--- a/blocks/init/src/Blocks/custom/columns/styles/_shared.scss
+++ b/blocks/init/src/Blocks/custom/columns/styles/_shared.scss
@@ -30,7 +30,7 @@ $block-columns: (
 		}
 	}
 
-	&__vertical-spacing {
+	&__verticalSpacing {
 		@include responsive-selectors {
 			$i: map-get-deep($block-columns, gutters, min);
 			@while $i <= map-get-deep($block-columns, gutters, max) {


### PR DESCRIPTION
_Vertical spacing_ was not being applied on the Columns block because of the wrong class name in the SCSS file.