### PR TITLE
Add component color helper

### DIFF
--- a/babel/babel.config.js
+++ b/babel/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
 	presets: [
 		"@wordpress/default",
+		"env"
 	],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',

--- a/babel/babel.config.js
+++ b/babel/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	presets: [
 		"@wordpress/default",
-		"env"
 	],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',

--- a/babel/babel.config.js
+++ b/babel/babel.config.js
@@ -17,4 +17,16 @@ module.exports = {
 			}
 		]
 	],
+	env: {
+		test: {
+			presets: [
+				[
+					'@babel/preset-env', {modules: 'commonjs'}
+				]
+			],
+			plugins: [
+				'@babel/plugin-transform-modules-commonjs'
+			]
+		}
+	}
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"sassdocBuild": "node ./node_modules/sassdoc/bin/sassdoc styles/scss --dest docs/sassdocs",
 		"docsBuild": "rm -rf docs && npm run sassdocBuild && npm run storybookBuild",
 		"docsDeploy": "npm run docsBuild && gh-pages -d docs",
-		"test": "jest --maxWorkers=2",
+		"test": "NODE_ENV=test jest --maxWorkers=2",
 		"testUnit": "jest --testPathPattern=tests/unit",
 		"testIntegration": "jest --testPathPattern=tests/integration"
 	},
@@ -90,6 +90,8 @@
 	},
 	"devDependencies": {
 		"@eightshift/storybook": "^5.6",
+		"@jest/globals": "^26.6.2",
+		"babel-preset-env": "^1.7.0",
 		"gh-pages": "^3.1.0",
 		"jest": "^26.6.3",
 		"sassdoc": "^2.7.3"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"docsBuild": "rm -rf docs && npm run sassdocBuild && npm run storybookBuild",
 		"docsDeploy": "npm run docsBuild && gh-pages -d docs",
 		"test": "NODE_ENV=test jest --maxWorkers=2",
-		"testUnit": "jest --testPathPattern=tests/unit",
+		"testUnit": "NODE_ENV=test jest --testPathPattern=tests/unit",
 		"testIntegration": "jest --testPathPattern=tests/integration"
 	},
 	"homepage": "https://github.com/infinum/eightshift-frontend-libs#readme",
@@ -91,7 +91,6 @@
 	"devDependencies": {
 		"@eightshift/storybook": "^5.6",
 		"@jest/globals": "^26.6.2",
-		"babel-preset-env": "^1.7.0",
 		"gh-pages": "^3.1.0",
 		"jest": "^26.6.3",
 		"sassdoc": "^2.7.3"

--- a/package.json
+++ b/package.json
@@ -89,11 +89,31 @@
 		}
 	},
 	"devDependencies": {
+		"@babel/plugin-transform-modules-commonjs": "^7.12.1",
 		"@eightshift/storybook": "^5.6",
 		"@jest/globals": "^26.6.2",
 		"gh-pages": "^3.1.0",
 		"jest": "^26.6.3",
 		"sassdoc": "^2.7.3"
 	},
-	"sideEffects": false
+	"sideEffects": false,
+	"jest": {
+		"verbose": true,
+		"transform": {
+			"^.+\\.js$": "babel-jest"
+		},
+		"globals": {
+			"NODE_ENV": "test"
+		},
+		"transformIgnorePatterns": ["/node_modules/"],
+		"moduleFileExtensions": [
+			"js"
+		],
+		"moduleDirectories": [
+			"node_modules",
+			"scripts",
+			"styles"
+		],
+		"automock": true
+	}
 }

--- a/scripts/editor/get-option-colors.js
+++ b/scripts/editor/get-option-colors.js
@@ -1,4 +1,4 @@
-import {getPaletteColors} from "./get-palette-colors";
+import { getPaletteColors } from "./get-palette-colors";
 
 /**
  * Use this hook to filter the global colors out of the component or block manifest

--- a/scripts/editor/get-option-colors.js
+++ b/scripts/editor/get-option-colors.js
@@ -4,6 +4,11 @@ import {getPaletteColors} from "./get-palette-colors";
  * Use this hook to filter the global colors out of the component or block manifest
  *
  * Requires WP => 5.3
+ *
+ * @param {array} colors Array of colors to filter.
+ *
+ * @return object
+ *
  */
 export const getOptionColors = (colors) => {
 	const coreColors = getPaletteColors();

--- a/scripts/editor/get-option-colors.js
+++ b/scripts/editor/get-option-colors.js
@@ -1,0 +1,16 @@
+import {getPaletteColors} from "./get-palette-colors";
+
+/**
+ * Use this hook to filter the global colors out of the component or block manifest
+ *
+ * Requires WP => 5.3
+ */
+export const getOptionColors = (colors) => {
+	const coreColors = getPaletteColors();
+
+	if (!Array.isArray(colors) || !colors.length) {
+		return Object.values(coreColors);
+	}
+
+	return colors.map((colorName) => coreColors[colorName]);
+};

--- a/tests/unit/scripts/editor/optionColors.test.js
+++ b/tests/unit/scripts/editor/optionColors.test.js
@@ -3,11 +3,8 @@
  *
  * @group unit
  */
-import { jest } from '@jest/globals';
 
-const { getOptionColors } = require("../../../../scripts/editor/get-option-colors");
-
-// Mock for getPaletteColors()
+// Mock for getPaletteColors() return value.
 const coreColors = {
 	"primary": {
 		"name": "Primary",
@@ -48,6 +45,7 @@ jest.mock('../../../../scripts/editor/get-palette-colors', () => ({
 	getPaletteColors: mockGetPaletteColors
 }));
 
+import { getOptionColors } from '../../../../scripts/editor/get-option-colors';
 
 it('tests optionColors helper returns correct color subset', () => {
 	const colors = getOptionColors(["primary", "white"]);
@@ -62,5 +60,6 @@ it('tests optionColors helper returns correct color subset', () => {
 
 it('tests optionColors helper fallbacks to core if no color is passed', () => {
 	const colors = getOptionColors();
+
 	expect(colors).toBe(Object.values(coreColors));
 });

--- a/tests/unit/scripts/editor/optionColors.test.js
+++ b/tests/unit/scripts/editor/optionColors.test.js
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for get-option-colors.js helper
+ *
+ * @group unit
+ */
+import { jest } from '@jest/globals';
+
+const { getOptionColors } = require("../../../../scripts/editor/get-option-colors");
+
+// Mock for getPaletteColors()
+const coreColors = {
+	"primary": {
+		"name": "Primary",
+		"slug": "primary",
+		"color": "#022687"
+	},
+	"black": {
+		"name": "Black",
+		"slug": "black",
+		"color": "#000000"
+	},
+	"white": {
+		"name": "White",
+		"slug": "white",
+		"color": "#FFFFFF"
+	},
+	"secondary": {
+		"name": "Secondary",
+		"slug": "secondary",
+		"color": "#05A8AA"
+	},
+	"caribbean": {
+		"name": "Caribbean",
+		"slug": "caribbean",
+		"color": "#06BDBF"
+	},
+	"transparent": {
+		"name": "Transparent",
+		"slug": "transparent",
+		"color": "transparent"
+	}
+};
+
+const mockGetPaletteColors = jest.fn().mockReturnValue(coreColors);
+
+jest.mock('../../../../scripts/editor/get-palette-colors', () => ({
+	__esModule: true,
+	getPaletteColors: mockGetPaletteColors
+}));
+
+
+it('tests optionColors helper returns correct color subset', () => {
+	const colors = getOptionColors(["primary", "white"]);
+
+	expect(colors).toBe(
+		[
+			{
+				"name": "Primary",
+				"slug": "primary",
+				"color": "#022687"
+			}, {
+				"name": "White",
+				"slug": "white",
+				"color": "#FFFFFF"
+			}
+		]
+	);
+});
+
+it('tests optionColors helper fallbacks to core if no color is passed', () => {
+	const colors = getOptionColors();
+	expect(colors).toBe(Object.values(coreColors));
+});

--- a/tests/unit/scripts/editor/optionColors.test.js
+++ b/tests/unit/scripts/editor/optionColors.test.js
@@ -54,15 +54,8 @@ it('tests optionColors helper returns correct color subset', () => {
 
 	expect(colors).toBe(
 		[
-			{
-				"name": "Primary",
-				"slug": "primary",
-				"color": "#022687"
-			}, {
-				"name": "White",
-				"slug": "white",
-				"color": "#FFFFFF"
-			}
+			coreColors.primary,
+			coreColors.white
 		]
 	);
 });


### PR DESCRIPTION
Added a helper that can be used in components to select only the colors defined in the component/block `manifest.json`. For instance if we have a component and inside we have 

```json
{
	"componentName": "some-component",
	"title": "Some Component",
	"componentClass": "some-component",
	"components": {
		"heading": "heading",
		"button": "button"
	},
	"options": {
		"colors": [
			"primary",
			"secondary",
			"tertiary",
			"maiden",
			"stratos",
			"caribbean",
			"white",
			"transparent"
		]
	}
}
```

and in the global manifest we have 

```json
{
	"namespace": "eightshift-boilerplate",
	"background": "#05A8AA",
	"foreground": "#FFFFFF",
	"globalVariables": {
		"customBlocksName": "eightshift-block",
		"maxCols": 12,
		"breakpoints": {
			"small": 320,
			"mobile": 767,
			"tablet": 991,
			"desktop": 1199,
			"large": 1200
		},
		"containers": {
			"default": "1200px",
			"big": "1440px",
			"narrow": "840px"
		},
		"containerGutter": {
			"default": "40px",
			"small": "20px",
			"none": "0"
		},
		"gutters": {
			"none": "0",
			"default": "30px",
			"big": "60px"
		},
		"sectionSpacing": {
			"min": -100,
			"max": 200,
			"step": 10
		},
		"sectionInSpacing": {
			"min": 0,
			"max": 200,
			"step": 10
		},
		"colors": [
			{
				"name": "Primary",
				"slug": "primary",
				"color": "#022687"
			},
			{
				"name": "Black",
				"slug": "black",
				"color": "#000000"
			},
			{
				"name": "White",
				"slug": "white",
				"color": "#FFFFFF"
			},
			{
				"name": "Maiden",
				"slug": "maiden",
				"color": "#0332B2"
			},
			{
				"name": "Stratos",
				"slug": "stratos",
				"color": "#011751"
			},
			{
				"name": "Secondary",
				"slug": "secondary",
				"color": "#05A8AA"
			},
			{
				"name": "Caribbean",
				"slug": "caribbean",
				"color": "#06BDBF"
			},
			{
				"name": "Iceberg",
				"slug": "iceberg",
				"color": "#E6F6F7"
			},
			{
				"name": "Mosque",
				"slug": "mosque",
				"color": "#036566"
			},
			{
				"name": "Tertiary",
				"slug": "tertiary",
				"color": "#FBA100"
			},
			{
				"name": "Golden",
				"slug": "golden",
				"color": "#FFC660"
			},
			{
				"name": "Zircon",
				"slug": "zircon",
				"color": "#F2F6FF"
			},
			{
				"name": "Zumbul",
				"slug": "zumbul",
				"color": "#E7EDFF"
			},
			{
				"name": "Ghost",
				"slug": "ghost",
				"color": "#CDD1DC"
			},
			{
				"name": "Manatee",
				"slug": "manatee",
				"color": "#808BA8"
			},
			{
				"name": "Fiord",
				"slug": "fiord",
				"color": "#4D5D82"
			},
			{
				"name": "Space",
				"slug": "space",
				"color": "#333940"
			},
			{
				"name": "Transparent",
				"slug": "transparent",
				"color": "transparent"
			}
		]
	}
}
```

Doing this inside the component

```js
const { title, options } = manifest;

getOptionColors(options.colors);
```

Should return an array of certain colors specified in the component `manifest.json`.

I've written tests, but they are failing so I need to fix this before mergeing.