### PR TITLE
Adding Yoast Seo helper

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/manifest.json
+++ b/blocks/init/src/Blocks/components/accordion/manifest.json
@@ -14,7 +14,8 @@
 			"type": "string"
 		},
 		"accordionContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"accordionIsOpen": {
 			"type": "boolean",

--- a/blocks/init/src/Blocks/components/button/manifest.json
+++ b/blocks/init/src/Blocks/components/button/manifest.json
@@ -17,7 +17,8 @@
 	},
 	"attributes": {
 		"buttonContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"buttonUrl": {
 			"type": "string"

--- a/blocks/init/src/Blocks/components/copyright/manifest.json
+++ b/blocks/init/src/Blocks/components/copyright/manifest.json
@@ -18,7 +18,8 @@
 			"type": "string"
 		},
 		"copyrightContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"copyrightUse": {
 			"type": "boolean",

--- a/blocks/init/src/Blocks/components/heading/manifest.json
+++ b/blocks/init/src/Blocks/components/heading/manifest.json
@@ -14,7 +14,8 @@
 	},
 	"attributes": {
 		"headingContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"headingLevel": {
 			"type": "integer",

--- a/blocks/init/src/Blocks/components/link/manifest.json
+++ b/blocks/init/src/Blocks/components/link/manifest.json
@@ -17,7 +17,8 @@
 	},
 	"attributes": {
 		"linkContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"linkUrl": {
 			"type": "string"

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -14,7 +14,8 @@
 	},
 	"attributes": {
 		"listsContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"listsOrdered": {
 			"type": "string",

--- a/blocks/init/src/Blocks/components/paragraph/manifest.json
+++ b/blocks/init/src/Blocks/components/paragraph/manifest.json
@@ -13,7 +13,8 @@
 	},
 	"attributes": {
 		"paragraphContent": {
-			"type": "string"
+			"type": "string",
+			"seo": true
 		},
 		"paragraphSize": {
 			"type": "string",

--- a/blocks/init/src/Blocks/components/scroll-to-top/manifest.json
+++ b/blocks/init/src/Blocks/components/scroll-to-top/manifest.json
@@ -11,7 +11,8 @@
 	"attributes": {
 		"scrollToTopContent": {
 			"type": "string",
-			"default": "To Top"
+			"default": "To Top",
+			"seo": true
 		},
 		"scrollToTopUse": {
 			"type": "boolean",

--- a/scripts/editor/index.js
+++ b/scripts/editor/index.js
@@ -5,5 +5,6 @@ export { ucfirst } from './ucfirst';
 export { icons } from './icons';
 export { overrideInnerBlockAttributes, overrideInnerBlockSimpleWrapperAttributes } from './override-inner-block-attributes';
 export { getOptionColors } from './get-option-colors';
+export { yoastSeo } from './yoast-seo';
 
 export const tabButtonClass = 'components-button is-button is-default custom-button-with-icon';

--- a/scripts/editor/yoast-seo.js
+++ b/scripts/editor/yoast-seo.js
@@ -1,0 +1,133 @@
+import domReady from '@wordpress/dom-ready';
+
+/* global YoastSEO */
+
+class YoastSEOCustomData {
+	constructor() {
+
+		// Ensure YoastSEO.js is present and can access the necessary features.
+		if ( typeof YoastSEO.analysis === 'undefined' || typeof YoastSEO.analysis.worker === 'undefined' ) {
+			return;
+		}
+
+		// Register custom class.
+			YoastSEO.app.registerPlugin( 'YoastSEOCustomData', { status: 'ready' } );
+
+			// Custom implementation.
+			this.registerModifications();
+	}
+
+	/**
+	 * Registers the addContent modification.
+	 *
+	 * @returns {void}
+	 */
+	registerModifications() {
+			const callback = this.addContent.bind( this );
+
+			// Ensure that the additional data is being seen as a modification to the content.
+			YoastSEO.app.registerModification( 'content', callback, 'YoastSEOCustomData', 10 );
+	}
+
+	/**
+	 * Adds to the content to be analyzed by the analyzer.
+	 *
+	 * @param {string} data The current data string.
+	 *
+	 * @returns {string} The data string parameter with the added content.
+	 */
+	addContent( data ) {
+
+			// First iteration always returns empty string so just skip this.
+			if(data === '') {
+				return data;
+			}
+
+			let newData = data;
+
+			newData += this.checkData(require.context(`./../../components`, true, /manifest.json$/), newData);
+			newData += this.checkData(require.context(`./../../custom`, true, /manifest.json$/), newData);
+
+			return newData;
+	}
+
+	// Check for the menifest data and append.
+	checkData(dataType, data) {
+
+		let output = '';
+
+		this.findManifests(dataType).forEach((element) => {
+			output += this.findStrings(element, data).map((item) => {
+				return item;
+			});
+		});
+
+		return output;
+	}
+
+	// Find all menifests in the provided require.context.
+	findManifests(items) {
+
+		const output = [];
+
+		// Find all attrobutes in that contains 
+		items.keys().map(items).forEach((item) => {
+
+			// Be sure tha that attributes key exists because it is not necesery to be present.
+			if (Object.prototype.hasOwnProperty.call(item, 'attributes')) {
+
+				// Loop attributes and find seo key.
+				for (const property in item.attributes) {
+					if (Object.prototype.hasOwnProperty.call(item.attributes[property], 'seo')) {
+						output.push(property);
+					}
+				}
+			}
+		});
+
+		return output;
+	}
+
+	// Find all strings using regex in the provided data set of dynamic attributes.
+	findStrings(key, data) {
+
+		console.log(key);
+
+		const regex = new RegExp(`"${key}":".*?"`, 'gm')
+		const output = [];
+		let iterator;
+
+		// Look regex items.
+		while ((iterator = regex.exec(data)) !== null) {
+
+			// This is necessary to avoid infinite loops with zero-width matches.
+			if (iterator.index === regex.lastIndex) {
+					regex.lastIndex++;
+			}
+
+			// The result can be accessed through the `iterator`-variable.
+			iterator.forEach((match) => {
+
+				// Split string, remove key, remove first and last quote.
+				output.push((match.split(':').pop().substring(1).slice(0,-1)));
+			});
+		}
+
+		return output;
+	}
+}
+
+export const yoastSeo = () => {
+	domReady(() => {
+		/**
+		* Adds eventlistener to load the plugin.
+		*/
+		if ( typeof YoastSEO !== 'undefined' && typeof YoastSEO.app !== 'undefined' ) {
+		new YoastSEOCustomData();
+		} else {
+			window.addEventListener('YoastSEO:ready', () => {
+				new YoastSEOCustomData();
+			});
+		}
+	});
+}

--- a/scripts/editor/yoast-seo.js
+++ b/scripts/editor/yoast-seo.js
@@ -51,7 +51,7 @@ class YoastSEOCustomData {
 			return newData;
 	}
 
-	// Check for the menifest data and append.
+	// Check for the manifest data and append.
 	checkData(dataType, data) {
 
 		let output = '';
@@ -65,12 +65,12 @@ class YoastSEOCustomData {
 		return output;
 	}
 
-	// Find all menifests in the provided require.context.
+	// Find all manifests in the provided require.context.
 	findManifests(items) {
 
 		const output = [];
 
-		// Find all attrobutes in that contains 
+		// Find all attributes in that contains.
 		items.keys().map(items).forEach((item) => {
 
 			// Be sure tha that attributes key exists because it is not necesery to be present.
@@ -90,8 +90,6 @@ class YoastSEOCustomData {
 
 	// Find all strings using regex in the provided data set of dynamic attributes.
 	findStrings(key, data) {
-
-		console.log(key);
 
 		const regex = new RegExp(`"${key}":".*?"`, 'gm')
 		const output = [];
@@ -119,11 +117,12 @@ class YoastSEOCustomData {
 
 export const yoastSeo = () => {
 	domReady(() => {
+
 		/**
-		* Adds eventlistener to load the plugin.
+		* Adds event listener to load the plugin.
 		*/
 		if ( typeof YoastSEO !== 'undefined' && typeof YoastSEO.app !== 'undefined' ) {
-		new YoastSEOCustomData();
+			new YoastSEOCustomData();
 		} else {
 			window.addEventListener('YoastSEO:ready', () => {
 				new YoastSEOCustomData();


### PR DESCRIPTION
Related to this issue https://github.com/infinum/eightshift-frontend-libs/issues/231

I have adde an script that you should just call in your `application-block-editor.js` like this:

```js
import { yoastSeo } from '@eightshift/frontend-libs/scripts/editor';

yoastSeo();
```

This helper will search all blocks and components manifests and find attributes that have `"seo": "true"` key.
This key will be added in to the content and proceed by the YoastSeo Analysis plugin.
