### PR TITLE
Block icon updates

### DIFF
--- a/blocks/init/src/Blocks/custom/accordion/manifest.json
+++ b/blocks/init/src/Blocks/custom/accordion/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "accordion block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -457)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 457h20v20h-20z'/><path fill-opacity='.12' fill='currentColor' opacity='.99' d='M2762 470h18v6h-18z'/><rect stroke='currentColor' stroke-width='1.5' x='2762' y='458' width='18' height='18' rx='1.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M2774 460.75l1.517 1.5 1.483-1.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M2765 461.5h4.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M2774 468.5l1.517-1.5 1.483 1.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M2765 467.75h4.5'/><g stroke='currentColor' stroke-linecap='round' stroke-width='1.5'><path d='M2765 471.5h8.5M2765 473.75h5.5'/></g><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M2762.5 464.75h17'/></g></svg>"
 	},
 	"keywords": [
 		"accordion"

--- a/blocks/init/src/Blocks/custom/button/manifest.json
+++ b/blocks/init/src/Blocks/custom/button/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Button block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><g transform='translate(1 6)' stroke='currentColor' stroke-width='1.5'><rect fill-opacity='.12' fill='currentColor' width='18' height='8' rx='1.5'/><path stroke-linecap='round' d='M5 4h8'/></g></g></svg>"
 	},
 	"keywords": [
 		"button",

--- a/blocks/init/src/Blocks/custom/card/manifest.json
+++ b/blocks/init/src/Blocks/custom/card/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Card with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "buddicons-buddypress-logo"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -177)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 177h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2762' y='178' width='18' height='18' rx='1.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='square' d='M2762.5 187.5h17'/><path fill-opacity='.12' fill='currentColor' d='M2762 178h18v9h-18z'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M2765.5 190.75h7M2765.5 193h3.5'/><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M2777.5 187.376l-3.065-3.146-2.91 3.146M2772.643 185.854l-3.13-4.104-4.826 5.583'/></g><circle fill='currentColor' cx='2774.25' cy='181.25' r='1.25'/></g></svg>"
 	},
 	"keywords": [
 		"Service",

--- a/blocks/init/src/Blocks/custom/carousel/manifest.json
+++ b/blocks/init/src/Blocks/custom/carousel/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Carousel block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-gallery"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -527)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 527h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2762' y='528' width='18' height='14' rx='1.5'/><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M2777.5 539.146l-3.065-3.146-2.91 3.146'/><path d='M2772.986 537.573l-3.473-4.553-4.826 5.583'/></g><circle fill='currentColor' cx='2774.5' cy='531.5' r='1.5'/><circle fill='currentColor' cx='2767' cy='545' r='1'/><circle fill='currentColor' opacity='.3' cx='2771' cy='545' r='1'/><circle fill='currentColor' opacity='.3' cx='2775' cy='545' r='1'/><path fill-opacity='.12' fill='currentColor' d='M2764.624 539.319l6.901.553h6.011l-2.871-3.623-1.489 1.324-3.481-4.203z'/></g></svg>"
 	},
 	"keywords": [
 		"carousel"

--- a/blocks/init/src/Blocks/custom/column/manifest.json
+++ b/blocks/init/src/Blocks/custom/column/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Column block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "<svg width=\"24\" height=\"24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\"><path d=\"M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z\"/></svg>"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -492)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 492h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' fill-opacity='.12' fill='currentColor' x='2766' y='493' width='10' height='18' rx='1.5'/></g></svg>"
 	},
 	"keywords": [
 		"column"

--- a/blocks/init/src/Blocks/custom/columns/manifest.json
+++ b/blocks/init/src/Blocks/custom/columns/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Columns block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "<svg width=\"24\" height=\"24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\"><path d=\"M4 4h16a2 2 0 012 2v12a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm0 2v12h4V6zm6 0v12h4V6zm6 0v12h4V6z\" /></svg>"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><g transform='translate(1 1)' fill='currentColor' fill-opacity='.12' stroke='currentColor' stroke-width='1.5'><rect width='4.5' height='18' rx='1.5'/><rect x='6.75' width='4.5' height='18' rx='1.5'/><rect x='13.5' width='4.5' height='18' rx='1.5'/></g></g></svg>"
 	},
 	"keywords": [
 		"columns"

--- a/blocks/init/src/Blocks/custom/example/manifest.json
+++ b/blocks/init/src/Blocks/custom/example/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Example Description",
 	"category": "eightshift",
 	"icon": {
-		"src": "heading"
+		"src": "<svg width='20' height='21' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2760 -979)' fill='none' fill-rule='evenodd'><path fill='none' d='M2760 979.5h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2761' y='980.5' width='18' height='18' rx='1.5'/><g stroke='currentColor' stroke-linejoin='round' stroke-width='1.5'><path d='M2768.668 989.147c.4 2.23.109 4.179-.871 5.846-1.47 2.5-5.493 1.48-4.53-1.239.642-1.812 2.443-3.347 5.401-4.607z'/><path d='M2768.06 989.44c-.23-2.287.207-4.22 1.309-5.8 1.653-2.37 5.584-.932 4.419 1.708-.777 1.76-2.687 3.124-5.729 4.091z'/></g><g stroke='currentColor' stroke-linecap='round' stroke-width='1.5'><path stroke-linejoin='round' d='M2771.662 992.152l2.68-2.388 1.184 3.423'/><path d='M2774.018 990.662l-1.504 4.67'/></g></g></svg>"
 	},
 	"keywords": [
 		"Example Keyword"

--- a/blocks/init/src/Blocks/custom/featured-categories-posts/manifest.json
+++ b/blocks/init/src/Blocks/custom/featured-categories-posts/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Block for selecting and displaying featured posts",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-aside"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><path d='M14.5 1A1.5 1.5 0 0116 2.5v10.304l-.53-.077L14 9.75l-1.47 2.977-3.285.478 2.377 2.318-.082.477H2.5A1.5 1.5 0 011 14.5v-12A1.5 1.5 0 012.5 1h12z' stroke='currentColor' stroke-width='1.5' stroke-linejoin='round'/><path stroke='currentColor' stroke-width='1.5' fill-opacity='.12' fill='currentColor' stroke-linejoin='round' d='M14 17.25l-2.939 1.545.561-3.272-2.377-2.318 3.286-.478L14 9.75l1.469 2.977 3.286.478-2.377 2.318.561 3.272z'/><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-opacity='.12' stroke-width='1.5'><path d='M4 6h9M4 9h6.5M4 12h3.5'/></g><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M4 5.5h9M4 8.5h6.5M4 11.5h3.5'/></g></g></svg>"
 	},
 	"keywords": [
 		"featured",

--- a/blocks/init/src/Blocks/custom/featured-categories/manifest.json
+++ b/blocks/init/src/Blocks/custom/featured-categories/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Block for selecting and displaying featured categories",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-aside"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><path d='M14.5 1A1.5 1.5 0 0116 2.5v10.304l-.53-.077L14 9.75l-1.47 2.977-3.285.478 2.377 2.318-.082.477H2.5A1.5 1.5 0 011 14.5v-12A1.5 1.5 0 012.5 1h12z' stroke='currentColor' stroke-width='1.5' stroke-linejoin='round'/><path stroke='currentColor' stroke-width='1.5' fill-opacity='.12' fill='currentColor' stroke-linejoin='round' d='M14 17.25l-2.939 1.545.561-3.272-2.377-2.318 3.286-.478L14 9.75l1.469 2.977 3.286.478-2.377 2.318.561 3.272zM4 4h3v3H4zM4 10h3v3H4zM10 4h3v3h-3z'/></g></svg>"
 	},
 	"keywords": [
 		"featured",

--- a/blocks/init/src/Blocks/custom/featured-posts/manifest.json
+++ b/blocks/init/src/Blocks/custom/featured-posts/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Block for selecting and displaying featured posts",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-aside"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><path d='M14.5 1A1.5 1.5 0 0116 2.5v10.304l-.53-.077L14 9.75l-1.47 2.977-3.285.478 2.377 2.318-.082.477H2.5A1.5 1.5 0 011 14.5v-12A1.5 1.5 0 012.5 1h12z' stroke='currentColor' stroke-width='1.5' stroke-linejoin='round'/><path stroke='currentColor' stroke-width='1.5' fill-opacity='.12' fill='currentColor' stroke-linejoin='round' d='M14 17.25l-2.939 1.545.561-3.272-2.377-2.318 3.286-.478L14 9.75l1.469 2.977 3.286.478-2.377 2.318.561 3.272z'/><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-opacity='.12' stroke-width='1.5'><path d='M4 6h9M4 9h6.5M4 12h3.5'/></g><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M4 5.5h9M4 8.5h6.5M4 11.5h3.5'/></g></g></svg>"
 	},
 	"keywords": [
 		"featured",

--- a/blocks/init/src/Blocks/custom/group/manifest.json
+++ b/blocks/init/src/Blocks/custom/group/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Group block used to grouping multiple blocks.",
 	"category": "eightshift",
 	"icon": {
-		"src": "screenoptions"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -247)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 247h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2765' y='251' width='8' height='8' rx='1.5'/><rect stroke='currentColor' stroke-width='1.5' x='2769' y='255' width='8' height='8' rx='1.5'/><path d='M2762.023 252v-2.5a1.5 1.5 0 011.5-1.5h2.5M2762.023 262v2.5a1.5 1.5 0 001.5 1.5h2.5M2780.023 252v-2.5a1.5 1.5 0 00-1.5-1.5h-2.5 0M2780.023 262v2.5a1.5 1.5 0 01-1.5 1.5h-2.5 0' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/><path fill-opacity='.12' fill='currentColor' d='M2769 255h4v4h-4z'/></g></svg>"
 	},
 	"keywords": [
 		"container",

--- a/blocks/init/src/Blocks/custom/heading/manifest.json
+++ b/blocks/init/src/Blocks/custom/heading/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Heading block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "heading"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><g fill='currentColor' fill-opacity='.12'><path d='M2 1h1v18H2a1 1 0 01-1-1V2a1 1 0 011-1zM3 17h16v1a1 1 0 01-1 1H3v-2z'/></g><path d='M17.5.25h-15A2.25 2.25 0 00.25 2.5v15a2.25 2.25 0 002.25 2.25h15a2.25 2.25 0 002.25-2.25v-15A2.25 2.25 0 0017.5.25zm-15 1.5h15a.75.75 0 01.75.75v15a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75v-15a.75.75 0 01.75-.75z' fill='currentColor' fill-rule='nonzero'/><path d='M7.62 14.5l.673-2.209h3.383l.673 2.209h2.12l-3.288-9.318H8.775L5.5 14.5h2.12zm3.587-3.86H8.788c.66-2.136 1.06-3.476 1.2-4.017.034.152.09.36.168.622.078.262.428 1.394 1.05 3.396z' fill='currentColor' fill-rule='nonzero'/><path fill-opacity='.12' fill='currentColor' d='M10.059 5.933l-2.309 5.4h4.642z'/></g></svg>"
 	},
 	"keywords": [
 		"heading",

--- a/blocks/init/src/Blocks/custom/image/manifest.json
+++ b/blocks/init/src/Blocks/custom/image/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Image block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-image"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -317)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 317h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2762' y='318' width='18' height='18' rx='1.5'/><g stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M2777.5 331.146l-3.065-3.146-2.91 3.146'/><path d='M2772.986 329.573l-3.473-4.553-4.826 5.583'/></g><circle fill='currentColor' cx='2774.5' cy='323.5' r='1.5'/><path fill-opacity='.12' fill='currentColor' d='M2764.624 331.319l6.901.553h6.011l-2.871-3.623-1.489 1.324-3.481-4.203z'/></g></svg>"
 	},
 	"keywords": [
 		"image",

--- a/blocks/init/src/Blocks/custom/jumbotron/manifest.json
+++ b/blocks/init/src/Blocks/custom/jumbotron/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Jumbotron block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "cover-image"
+		"src": "<svg width='20' height='21' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2760 -735)' fill='none' fill-rule='evenodd'><path fill='none' d='M2760 735.5h20v20h-20z'/><path fill-opacity='.12' fill='currentColor' d='M2761 737h18v10h-18z'/><rect stroke='currentColor' stroke-width='1.5' x='2761' y='736.5' width='18' height='18' rx='1.5'/><g stroke='currentColor' stroke-linecap='round' stroke-width='1.5'><path d='M2764.5 740.75h11M2766.5 743.75h7'/></g><rect stroke='currentColor' stroke-width='1.5' stroke-linejoin='round' x='2766.5' y='749' width='7' height='3' rx='1.5'/></g></svg>"
 	},
 	"keywords": [
 		"jumbotron",

--- a/blocks/init/src/Blocks/custom/link/manifest.json
+++ b/blocks/init/src/Blocks/custom/link/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Link block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><path d='M7.25 6a.75.75 0 01.11 1.492l-.11.008H5a3.5 3.5 0 00-.206 6.994L5 14.5h2.25a.75.75 0 01.11 1.492L7.25 16H5a5 5 0 01-.25-9.994L5 6h2.25zM15 6a5 5 0 01.25 9.994L15 16h-2.25a.75.75 0 01-.11-1.492l.11-.008H15a3.5 3.5 0 00.206-6.994L15 7.5h-2.25a.75.75 0 01-.11-1.492L12.75 6H15zM5 10.25h10a.75.75 0 01.102 1.493L15 11.75H5a.75.75 0 01-.102-1.493L5 10.25h10H5z' fill-opacity='.12' fill='currentColor' fill-rule='nonzero'/><path d='M7.25 5a.75.75 0 01.11 1.492l-.11.008H5a3.5 3.5 0 00-.206 6.994L5 13.5h2.25a.75.75 0 01.11 1.492L7.25 15H5a5 5 0 01-.25-9.994L5 5h2.25zM15 5a5 5 0 01.25 9.994L15 15h-2.25a.75.75 0 01-.11-1.492l.11-.008H15a3.5 3.5 0 00.206-6.994L15 6.5h-2.25a.75.75 0 01-.11-1.492L12.75 5H15zM5 9.25h10a.75.75 0 01.102 1.493L15 10.75H5a.75.75 0 01-.102-1.493L5 9.25h10H5z' fill='currentColor' fill-rule='nonzero'/></g></svg>"
 	},
 	"keywords": [
 		"link",

--- a/blocks/init/src/Blocks/custom/lists/manifest.json
+++ b/blocks/init/src/Blocks/custom/lists/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "lists block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><g transform='translate(3 2.75)' fill='currentColor' fill-opacity='.12' stroke='currentColor' stroke-width='1.5'><circle cx='1.5' cy='1.5' r='1.5'/><circle cx='1.5' cy='7.5' r='1.5'/><circle cx='1.5' cy='13.5' r='1.5'/></g><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M9.5 4.25H17M9.5 10.25H17M9.5 16.25H17'/></g></svg>"
 	},
 	"keywords": [
 		"lists",

--- a/blocks/init/src/Blocks/custom/paragraph/manifest.json
+++ b/blocks/init/src/Blocks/custom/paragraph/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "Paragraph block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "editor-paragraph"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2807 -422)' fill='none' fill-rule='evenodd'><path fill='none' d='M2807 422h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2808' y='423' width='18' height='18' rx='1.5'/><g fill='currentColor' fill-opacity='.12'><path d='M2809 423h1v18h-1a1 1 0 01-1-1v-16a1 1 0 011-1zM2810 439h16v1a1 1 0 01-1 1h-15v-2z'/></g><g fill='currentColor'><path fill-opacity='.12' d='M2817.783 426.877h2v11.151h-2z'/><path d='M2818.115 438.027V427.77h1.053v10.257h1.022V426.5h-3.834c-.981 0-1.703.269-2.164.806-.461.538-.692 1.356-.692 2.457 0 1.062.215 1.857.644 2.386.43.53 1.102.794 2.016.794.355 0 .664-.038.926-.114v5.198h1.029z' fill-rule='nonzero'/></g></g></svg>"
 	},
 	"keywords": [
 		"paragraph",

--- a/blocks/init/src/Blocks/custom/video/manifest.json
+++ b/blocks/init/src/Blocks/custom/video/manifest.json
@@ -4,7 +4,7 @@
 	"description" : "video block with custom settings.",
 	"category": "eightshift",
 	"icon": {
-		"src": "format-video"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2761 -632)' fill='none' fill-rule='evenodd'><path fill='none' d='M2761 632h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2762' y='633' width='18' height='18' rx='1.5'/><path stroke='currentColor' stroke-width='1.5' fill-opacity='.12' fill='currentColor' stroke-linejoin='round' d='M2774.5 642.5l-6 3.5v-7z'/><g fill='currentColor' fill-opacity='.12'><path d='M2763 633h1v18h-1a1 1 0 01-1-1v-16a1 1 0 011-1zM2764 649h16v1a1 1 0 01-1 1h-15v-2z'/></g></g></svg>"
 	},
 	"keywords": [
 		"video",

--- a/blocks/init/src/Blocks/manifest.json
+++ b/blocks/init/src/Blocks/manifest.json
@@ -1,7 +1,7 @@
 {
 	"namespace": "eightshift-boilerplate",
-	"background": "#900000",
-	"foreground": "#FFFFFF",
+	"background": "#FFFFFF",
+	"foreground": "#0D3636",
 	"globalVariables": {
 		"customBlocksName": "eightshift-block",
 		"maxCols": 12,

--- a/blocks/init/src/Blocks/variations/button-block/manifest.json
+++ b/blocks/init/src/Blocks/variations/button-block/manifest.json
@@ -4,7 +4,7 @@
 	"title": "Button Full Width",
 	"description" : "Button Block Variation for full width style.",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='20' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><path fill='none' d='M0 0h20v20H0z'/><g transform='translate(1 3)' stroke='currentColor' stroke-width='1.5'><rect fill-opacity='.12' fill='currentColor' width='18' height='8' rx='1.5'/><path stroke-linecap='round' d='M5 4h8'/></g><path d='M17.353 16.196l-.073.084-2 2a.75.75 0 01-1.133-.976l.073-.084.706-.707H5.575l.705.707.073.084a.75.75 0 01-1.133.976l-2-2-.073-.084a.75.75 0 01.073-.976l2-2 .084-.073a.75.75 0 01.976.073l.073.084a.75.75 0 01-.073.976l-.732.733h9.405l-.733-.733a.75.75 0 01-.073-.976l.073-.084a.75.75 0 01.976-.073l.084.073 2 2a.75.75 0 01.073.976z' fill='currentColor' fill-rule='nonzero'/></g></svg>"
 	},
 	"example": {
 		"attributes": {

--- a/blocks/init/src/Blocks/variations/card-simple/manifest.json
+++ b/blocks/init/src/Blocks/variations/card-simple/manifest.json
@@ -4,7 +4,7 @@
 	"title": "Card Simple",
 	"description" : "Card Block Variation for simple style.",
 	"icon": {
-		"src": "editor-removeformatting"
+		"src": "<svg width='20' height='21' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-2760 -700)' fill='none' fill-rule='evenodd'><path fill='none' d='M2760 700.5h20v20h-20z'/><rect stroke='currentColor' stroke-width='1.5' x='2761' y='701.5' width='18' height='18' rx='1.5'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='square' d='M2761.5 711h17'/><path stroke='currentColor' stroke-width='1.5' stroke-linecap='round' d='M2764.5 714.25h7M2764.5 716.5h3.5'/><path d='M2776.168 710.609l-2.655-2.879-2.524 2.594.771-.809-3.247-4.265-4.826 5.583' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-opacity='.12' stroke-width='1.5'/><circle fill-opacity='.12' fill='currentColor' cx='2773.25' cy='704.75' r='1.25'/></g></svg>"
 	},
 	"example": {
 		"attributes": {


### PR DESCRIPTION
Closes #257.

- new block icons
- color scheme change from red-white to white-eightshiftBlack

Exported, minified and optimized icons not currently used (but still on the list below) will be a `.txt` file on Drive.

Icon list:
![image](https://user-images.githubusercontent.com/77000136/106631859-726d1180-657d-11eb-8426-119fb501f6eb.png)