### PR TITLE
updating fix to remove php file from build

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -47,6 +47,7 @@ module.exports = (options) => {
 	// Enable export for all WordPress related packages
 	if (!options.overrides.includes('DependencyExtractionWebpackPlugin')) {
 		plugins.push(new DependencyExtractionWebpackPlugin({
+			outputFormat: 'json',
 			requestToExternal: function ( request ) {
 				if ( request === '@wordpress/dom-ready' ) {
 					return '';


### PR DESCRIPTION
DependencyExtractionWebpackPlugin outputs file to manage dependencies internally. I have switched this to json file

https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin