### PR TITLE
updating browserSync https

### DIFF
--- a/webpack/development.js
+++ b/webpack/development.js
@@ -13,16 +13,25 @@ module.exports = (options) => {
 
 	// Use BrowserSync to see live preview of all changes.
 	if (!options.overrides.includes('browserSyncPlugin')) {
-		plugins.push(new BrowserSyncPlugin({
+		const syncConfig = {
 			host: 'localhost',
 			port: 3000,
-			proxy: options.config.proxyUrl,
-		}, {
+			proxy: `http://${options.config.proxyUrl}`,
+		};
 
-			// prevent BrowserSync from reloading the page
-			// and let Webpack Dev Server take care of this
-			reload: false,
-		}));
+		if (options.config.useSsl) {
+			syncConfig.proxy = `https://${options.config.proxyUrl}`;
+			syncConfig.https = true;
+		}
+
+		plugins.push(new BrowserSyncPlugin(
+			syncConfig,
+			{
+				// prevent BrowserSync from reloading the page
+				// and let Webpack Dev Server take care of this
+				reload: false,
+			}
+		));
 	}
 
 	return {

--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -12,6 +12,7 @@ const path = require('path');
  * @param {string} proxyUrl Used for providing browsersync functionality.
  * @param {string} projectPathConfig Project path relative to project root.
  * @param {string} assetsPathConfig Assets path after projectPath location.
+ * @param {string} blocksAssetsPathConfig Path of the block assets.
  * @param {string} outputPathConfig Public output path after projectPath location.
  * @param {string} blocksManifestSettingsPath Main global settings manifest.json path after projectPath location.
  * @param {boolean} useSsl Change configuration if you have local ssl certificate, generally used only for BrowserSync.

--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -12,12 +12,21 @@ const path = require('path');
  * @param {string} proxyUrl Used for providing browsersync functionality.
  * @param {string} projectPathConfig Project path relative to project root.
  * @param {string} assetsPathConfig Assets path after projectPath location.
- * @param {string} blocksAssetsPathConfig Path of the block assets.
  * @param {string} outputPathConfig Public output path after projectPath location.
  * @param {string} blocksManifestSettingsPath Main global settings manifest.json path after projectPath location.
+ * @param {boolean} useSsl Change configuration if you have local ssl certificate, generally used only for BrowserSync.
  *
  */
-function getConfig(projectDir, proxyUrl, projectPathConfig, assetsPathConfig = 'assets', blocksAssetsPathConfig = 'src/Blocks/assets', outputPathConfig = 'public', blocksManifestSettingsPath = 'src/Blocks/manifest.json') {
+function getConfig(
+		projectDir,
+		proxyUrl,
+		projectPathConfig,
+		assetsPathConfig = 'assets',
+		blocksAssetsPathConfig = 'src/Blocks/assets',
+		outputPathConfig = 'public',
+		blocksManifestSettingsPath = 'src/Blocks/manifest.json',
+		useSsl = false
+	) {
 
 	if (typeof projectDir === 'undefined') {
 		throw Error('projectDir parameter is empty, please provide. This key represents: Current project directory absolute path. For example: __dirname');
@@ -58,6 +67,8 @@ function getConfig(projectDir, proxyUrl, projectPathConfig, assetsPathConfig = '
 		applicationBlocksEditorEntry: path.resolve(absolutePath, blocksAssetsPathConfigClean, 'application-blocks-editor.js'),
 
 		blocksManifestSettingsPath: path.resolve(absolutePath, blocksManifestSettingsPathClean),
+
+		useSsl,
 	};
 }
 

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -22,7 +22,9 @@ module.exports = (mode, optionsData = {}) => {
 		optionsData.config.projectPath,
 		optionsData.config.assetsPath,
 		optionsData.config.blocksAssetsPath,
-		optionsData.config.outputPath
+		optionsData.config.outputPath,
+		optionsData.config.blocksManifestSettingsPath,
+		optionsData.config.useSsl
 	);
 
 	options.config.mode = mode;


### PR DESCRIPTION
I have updated the Webpack so you can now in webpack.config.js provide only useSsl: true key and it will automatically convert browserSync to https. No need for custom setup 