### PR TITLE
Add options to feature-posts manifest

### DIFF
--- a/blocks/init/src/Blocks/custom/featured-posts/manifest.json
+++ b/blocks/init/src/Blocks/custom/featured-posts/manifest.json
@@ -77,6 +77,12 @@
 			"min": 1,
 			"max": 4,
 			"step": 1
-		}
+		},
+		"breakpoints": [
+			"large",
+			"desktop",
+			"tablet",
+			"mobile"
+		]
 	}
 }


### PR DESCRIPTION
There is a reference to `options.breakpoints` inside the `featured-posts-options.js` component. Without the options in the manifest, this breaks the implementation.