### PR TITLE
Add filter component options helper

### DIFF
--- a/scripts/editor/filter-component-options.js
+++ b/scripts/editor/filter-component-options.js
@@ -1,0 +1,62 @@
+/**
+ * Use this hook to filter the component options based on the options defined in parent component
+ *
+ * Step 1:
+ * Inside the parent component define the options you want to show.
+ * Example:
+ *	"options": {
+ *		"heading": {
+ *			"colors": [
+ *				"richBlack",
+ *				"white"
+ *			],
+ *			"sizes": [
+ *				"xl",
+ *				"l"
+ *			]
+ *		}
+ * 	}
+ *
+ * Step 2:
+ * Inside the parents component options.js file where you render the component
+ * add the options you defined in parent manifest to the the componentNameOptions attribute
+ * Example:
+ * <HeadingOptions
+ * 	{...attributes}
+ * 	headingOptions={manifest.options.heading}
+ * 	setAttributes={setAttributes}
+ * />
+ *
+ * Step 3:
+ * Inside the components options.js file add the helper function.
+ *
+ * Requires WP => 5.3
+ *
+ * @param {array} attributes Attributes from the parent component.
+ * @param {array} componentName Component name from the used component.
+ * @param {array} options Options array from the component.
+ *
+ * @return object
+ *
+ */
+export const filterComponentOptions = (attributes, componentName, options) => {
+
+	if (!attributes[`${componentName}Options`]) {
+		return;
+	}
+
+	Object.keys(options).forEach(
+		(key) => {
+			const values = options[key];
+
+			const limitedValues = attributes[`${componentName}Options`][key];
+
+			if(!limitedValues) {
+				return;
+			}
+
+			options[key] = values.filter(entry => limitedValues.includes(entry.value ?? entry));
+
+		}
+	);
+}

--- a/scripts/editor/filter-component-options.js
+++ b/scripts/editor/filter-component-options.js
@@ -47,13 +47,14 @@ export const filterComponentOptions = (attributes, componentName, options) => {
 
 	Object.keys(options).forEach(
 		(key) => {
-			const values = options[key];
 
 			const limitedValues = attributes[`${componentName}Options`][key];
 
 			if(!limitedValues) {
 				return;
 			}
+
+			const values = options[key];
 
 			options[key] = values.filter(entry => limitedValues.includes(entry.value ?? entry));
 

--- a/scripts/editor/index.js
+++ b/scripts/editor/index.js
@@ -6,3 +6,4 @@ export { icons } from './icons/icons';
 export { overrideInnerBlockAttributes, overrideInnerBlockSimpleWrapperAttributes } from './override-inner-block-attributes';
 export { getOptionColors } from './get-option-colors';
 export { pasteInto } from './paste-handler';
+export { filterComponentOptions } from './filter-component-options';


### PR DESCRIPTION
@goranalkovic-infinum and I created this helper for filtering component options.

Use case example:
You have a parent component that uses a different component for example the heading component.
The heading component has 10 different color options and 5 different size options, but you don't need all of them in your parent component.

With this helper, you can define the options you want inside the parent component and it will dynamically filter them out.

How does it work? See the Doc comment inside the helper functions. 😃 