### PR TITLE
Fixed image alignment

### DIFF
--- a/blocks/init/src/Blocks/components/image/image-style.scss
+++ b/blocks/init/src/Blocks/components/image/image-style.scss
@@ -26,8 +26,8 @@
 	}
 
 	&[data-align='top center'] {
-		align-items: flex-start;
-		justify-content: center;
+		align-items: center;
+		justify-content: flex-start;
 
 		.image--bg {
 			background-position: center top;
@@ -35,8 +35,8 @@
 	}
 
 	&[data-align='top right'] {
-		align-items: flex-start;
-		justify-content: flex-end;
+		align-items: flex-end;
+		justify-content: flex-start;
 
 		.image--bg {
 			background-position: right top;
@@ -44,8 +44,8 @@
 	}
 
 	&[data-align='center left'] {
-		align-items: center;
-		justify-content: flex-start;
+		align-items: flex-start;
+		justify-content: center;
 
 		.image--bg {
 			background-position: left center;
@@ -62,8 +62,8 @@
 	}
 
 	&[data-align='center right'] {
-		align-items: center;
-		justify-content: flex-end;
+		align-items: flex-end;
+		justify-content: center;
 
 		.image--bg {
 			background-position: right center;
@@ -71,8 +71,8 @@
 	}
 
 	&[data-align='bottom left'] {
-		align-items: flex-end;
-		justify-content: flex-start;
+		align-items: flex-start;
+		justify-content: flex-end;
 
 		.image--bg {
 			background-position: left bottom;
@@ -80,8 +80,8 @@
 	}
 
 	&[data-align='bottom center'] {
-		align-items: flex-end;
-		justify-content: center;
+		align-items: center;
+		justify-content: flex-end;
 
 		.image--bg {
 			background-position: center bottom;


### PR DESCRIPTION
Probably caused by changing flexbox orientation in https://github.com/infinum/eightshift-frontend-libs/commit/c92d5d525bb428312854db2f0a0bdf75ce38082c commit

Changelog:
- image alignment fix

Screenshots:
![Screen Shot 2021-03-04 at 10 57 05 AM](https://user-images.githubusercontent.com/46056662/109946400-7e610600-7cd8-11eb-970d-2296ad3e136f.png)
![Screen Shot 2021-03-04 at 10 57 09 AM](https://user-images.githubusercontent.com/46056662/109946406-7f923300-7cd8-11eb-95ad-a5bf4c2496b1.png)
![Screen Shot 2021-03-04 at 10 57 13 AM](https://user-images.githubusercontent.com/46056662/109946410-802ac980-7cd8-11eb-9785-7f44998fde6d.png)
![Screen Shot 2021-03-04 at 10 57 16 AM](https://user-images.githubusercontent.com/46056662/109946412-802ac980-7cd8-11eb-850c-3ec02653c63a.png)
![Screen Shot 2021-03-04 at 10 57 20 AM](https://user-images.githubusercontent.com/46056662/109946413-80c36000-7cd8-11eb-9f69-682199cb7bd6.png)
![Screen Shot 2021-03-04 at 10 57 24 AM](https://user-images.githubusercontent.com/46056662/109946420-815bf680-7cd8-11eb-9a13-db6ccb8c4e14.png)
