### PR TITLE
Fix setup script overriding libs and frontend libs branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ package-lock.json
 /temp
 /temp-plugin
 /temp-theme
+
+# Local env settings
+.vscode/settings.json

--- a/setup/create-wp-project/package.json
+++ b/setup/create-wp-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-wp-project",
   "description": "This is a setup script for creating a WordPress project.",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "author": "Team Eightshift",
   "main": "",
   "license": "MIT",

--- a/setup/create-wp-project/src/basics/command-line.js
+++ b/setup/create-wp-project/src/basics/command-line.js
@@ -13,6 +13,7 @@ const cloneRepoTo = async (repo, folderName, branch = '') => {
 const installNodeDependencies = async (projectPath) => exec(`cd "${projectPath}" && npm install`);
 const installNodePackage = async (projectPath, packageToInstall) => exec(`cd "${projectPath}" && npm install ${packageToInstall}`);
 const installComposerDependencies = async (projectPath) => exec(`cd "${projectPath}" && composer install --ignore-platform-reqs`);
+const installComposerPackage = async (projectPath, packageToInstall) => exec(`cd "${projectPath}" && composer require ${packageToInstall} --ignore-platform-reqs`);
 const wpCoreDownload = async (projectPath) => exec(`cd "${projectPath}" && wp core download`);
 
 module.exports = {
@@ -20,5 +21,6 @@ module.exports = {
   installNodeDependencies,
   installNodePackage,
   installComposerDependencies,
+  installComposerPackage,
   wpCoreDownload,
 };

--- a/setup/create-wp-project/src/commands/plugin.js
+++ b/setup/create-wp-project/src/commands/plugin.js
@@ -21,6 +21,7 @@ const {
 const { searchReplace } = require('../search-replace');
 const { cleanup } = require('../cleanup');
 const { scriptArguments } = require('../arguments');
+const { installModifiedComposerDependencies, installModifiedNodeDependencies } = require('../dependencies');
 
 exports.command = 'plugin';
 exports.desc = 'Setup a new WordPress plugin. Should be run inside your plugins folder (wp-content/plugins).';
@@ -41,10 +42,18 @@ exports.handler = async (argv) => {
   });
   step++;
 
-  await installStep({
-    describe: `${step}. Installing Node dependencies`,
-    thisHappens: installNodeDependencies(projectPath),
-  });
+  // Install all node packages as is or overwrite frontend-libs
+  if (argv.eightshiftFrontendLibsBranch) {
+    await installStep({
+      describe: `${step}. Installing modified Node dependencies`,
+      thisHappens: installModifiedNodeDependencies(projectPath, argv.eightshiftFrontendLibsBranch),
+    });
+  } else {
+    await installStep({
+      describe: `${step}. Installing Node dependencies`,
+      thisHappens: installNodeDependencies(projectPath),
+    });
+  }
   step++;
 
   await installStep({
@@ -53,10 +62,18 @@ exports.handler = async (argv) => {
   });
   step++;
 
-  await installStep({
-    describe: `${step}. Installing Composer dependencies`,
-    thisHappens: installComposerDependencies(projectPath),
-  });
+  // Install all composer packages as is or overwrite libs
+  if (argv.eightshiftLibsBranch) {
+    await installStep({
+      describe: `${step}. Installing modified Composer dependencies`,
+      thisHappens: installModifiedComposerDependencies(projectPath, argv.eightshiftLibsBranch),
+    });
+  } else {
+    await installStep({
+      describe: `${step}. Installing Composer dependencies`,
+      thisHappens: installComposerDependencies(projectPath),
+    });
+  }
   step++;
 
   await installStep({

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -19,7 +19,7 @@ const {
 const { searchReplace } = require('../search-replace');
 const { cleanup } = require('../cleanup');
 const { scriptArguments } = require('../arguments');
-const { installModifiedNodeDependencies } = require('../dependencies');
+const { installModifiedNodeDependencies, installModifiedComposerDependencies } = require('../dependencies');
 
 exports.command = ['*', 'theme'];
 exports.desc = 'Setup a new WordPress theme. Should be run inside your theme folder (wp-content/themes).';
@@ -59,10 +59,18 @@ exports.handler = async (argv) => {
   });
   step++;
 
-  await installStep({
-    describe: `${step}. Installing Composer dependencies`,
-    thisHappens: installComposerDependencies(projectPath),
-  });
+  // Install all composer packages as is or overwrite libs
+  if (argv.eightshiftLibsBranch) {
+    await installStep({
+      describe: `${step}. Installing modified Composer dependencies`,
+      thisHappens: installModifiedComposerDependencies(projectPath, argv.eightshiftLibsBranch),
+    });
+  } else {
+    await installStep({
+      describe: `${step}. Installing Composer dependencies`,
+      thisHappens: installComposerDependencies(projectPath),
+    });
+  }
   step++;
 
   await installStep({

--- a/setup/create-wp-project/src/dependencies.js
+++ b/setup/create-wp-project/src/dependencies.js
@@ -1,7 +1,9 @@
-const { installNodePackage } = require('./basics/command-line');
+const { installNodePackage, installComposerPackage } = require('./basics/command-line');
 
 const eightshiftLibsName = '';
+const eightshiftLibsRepo = 'infinum/eightshift-libs';
 const eightshiftFrontendLibsRepo = 'infinum/eightshift-frontend-libs';
+const eightshiftFrontendLibsRepoUrl = 'https://github.com/infinum/eightshift-frontend-libs';
 
 /**
  * Check if we need to modify dependencies (if user passed an alternative branch for any dependency
@@ -20,8 +22,17 @@ const areDependenciesModified = (argv) => {
  * @param {array} branch Name of the branch to pull from.
  */
 const installModifiedNodeDependencies = async (projectPath, branch) => {
-  return installNodePackage(projectPath, `${eightshiftFrontendLibsRepo}#${branch} --save`);
+  return installNodePackage(projectPath, `${eightshiftFrontendLibsRepoUrl}#${branch} --save`);
+};
 
+/**
+ * Installs composer packages and modifies the libs to a specific branch.
+ *
+ * @param {string} projectPath Path to the project.
+ * @param {array} branch Name of the branch to pull from.
+ */
+const installModifiedComposerDependencies = async (projectPath, branch) => {
+  return installComposerPackage(projectPath, `${eightshiftLibsRepo}:dev-${branch}`);
 };
 
 module.exports = {
@@ -29,4 +40,5 @@ module.exports = {
   eightshiftFrontendLibsRepo,
   areDependenciesModified,
   installModifiedNodeDependencies,
+  installModifiedComposerDependencies,
 };


### PR DESCRIPTION
Changelog
---
* Fixes #312 (allow proper overwriting of libs / frontend libs branches during setup using `--eightshiftLibsBranch` and `--eightshiftFrontendLibsBranch` arguments during `npx create-wp-project`)
* Gitignore vsode workspace settings file

Note, these 2 arguments for overriding branches should only be used for testing because they will make your libs / frontend libs dependencies locked to those specific branches if you ever update your packages in the future and might break your install.