### PR TITLE
Block icon display fixes

### DIFF
--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -206,6 +206,14 @@ export const getIconOptions = (globalManifest, blockManifest) => {
 		return {};
 	}
 
+	// Add icon foreground and background colors as CSS variables for later use.
+	try {
+		document.documentElement.style.setProperty('--eightshift-block-icon-foreground', foregroundGlobal);
+		document.documentElement.style.setProperty('--eightshift-block-icon-background', backgroundGlobal);
+	} catch (error) {
+		// Do nothing.
+	}
+
 	// Use built-in icons if 'src' is provided and the
 	// icon exists in the library
 	if (icon.src !== undefined && blockIcons[icon.src] !== undefined) {

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -206,14 +206,6 @@ export const getIconOptions = (globalManifest, blockManifest) => {
 		return {};
 	}
 
-	// Add icon foreground and background colors as CSS variables for later use.
-	try {
-		document.documentElement.style.setProperty('--eightshift-block-icon-foreground', foregroundGlobal);
-		document.documentElement.style.setProperty('--eightshift-block-icon-background', backgroundGlobal);
-	} catch (error) {
-		// Do nothing.
-	}
-
 	// Use built-in icons if 'src' is provided and the
 	// icon exists in the library
 	if (icon.src !== undefined && blockIcons[icon.src] !== undefined) {
@@ -543,6 +535,14 @@ export const registerBlocks = (
 
 	buildWindowObject(globalManifest, componentsManifest, blocksManifests, wrapperManifest);
 
+	// Add icon foreground and background colors as CSS variables for later use.
+	const {
+		background: backgroundGlobal,
+		foreground: foregroundGlobal,
+	} = globalManifest;
+
+	document.documentElement.style.setProperty('--eightshift-block-icon-foreground', foregroundGlobal);
+	document.documentElement.style.setProperty('--eightshift-block-icon-background', backgroundGlobal);
 };
 
 /**
@@ -614,7 +614,7 @@ export const buildDependencyComponentsTree = (components) => {
 export const buildDependencyComponentsInnerTree = (componentsList, components) => {
 	let output = [];
 
-	if ( typeof componentsList === 'undefined' ) {
+	if (typeof componentsList === 'undefined') {
 		return output;
 	}
 

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -205,4 +205,10 @@ body {
 		text-align: center;
 		justify-content: center;
 	}
+
+	// Fix for disabled button icon foregrounds.
+	button[disabled] .block-editor-block-icon.has-colors {
+		background-color: transparent !important;
+		opacity: 1 !important;
+	}
 }

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -217,4 +217,42 @@ body {
 	.components-button.block-editor-block-switcher__no-switcher-icon:disabled .block-editor-block-icon.has-colors {
 		color: var(--eightshift-block-icon-foreground, #333333) !important;
 	}
+
+	// Enlarge the icons in the Options panel a bit.
+	.block-editor-block-card .block-editor-block-icon {
+		height: 2.1rem !important;
+		width: 2.25rem !important;
+		border-radius: 4px;
+
+		svg {
+			transform: scale(1.15);
+		}
+	}
+
+	// Enlarge the icons in the toolbar a bit.
+	button[disabled] .block-editor-block-icon.has-colors,
+	.components-button.components-toolbar-button.block-editor-block-parent-selector__button.has-icon .block-editor-block-icon,
+	.block-editor-block-toolbar__block-controls
+	.block-editor-block-switcher 
+	.components-dropdown-menu__toggle
+	.block-editor-block-icon {
+		height: 1.75rem !important;
+		width: 1.75rem !important;
+		border-radius: 4px;
+
+		svg {
+			transform: scale(1.1);
+		}
+	}
+
+	.components-accessible-toolbar .components-toolbar-group>.components-button.components-button.has-icon svg {
+		min-width: unset !important;
+	}
+
+	// Enlarge icon in component menu.
+	.components-menu-item__item .block-editor-block-icon {
+		height: 1.75rem !important;
+		width: 1.75rem !important;
+		border-radius: 4px;
+	}
 }

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -206,9 +206,15 @@ body {
 		justify-content: center;
 	}
 
-	// Fix for disabled button icon foregrounds.
-	button[disabled] .block-editor-block-icon.has-colors {
-		background-color: transparent !important;
+	// Fix for disabled button icon foregrounds and backgrounds.
+	button[disabled] .block-editor-block-icon.has-colors,
+	.components-button.components-toolbar-button.block-editor-block-parent-selector__button.has-icon .block-editor-block-icon {
+		background-color: var(--eightshift-block-icon-background, transparent) !important;
+		color: var(--eightshift-block-icon-foreground, #333333) !important;
 		opacity: 1 !important;
+	}
+
+	.components-button.block-editor-block-switcher__no-switcher-icon:disabled .block-editor-block-icon.has-colors {
+		color: var(--eightshift-block-icon-foreground, #333333) !important;
 	}
 }


### PR DESCRIPTION
Fixes #265

- on block registration 2 new CSS variables (`--eightshift-block-icon-foreground` and `--eightshift-block-icon-background`) are set, corresponding to global block icon foreground/background colors
- icon background shows correct colors now if no transforms are available on the block (see image)
- tweaked spacings and alignments of icons to make them look a bit better and not be too close to backplate edges (see image)

![image](https://user-images.githubusercontent.com/77000136/114735789-d104f780-9d45-11eb-80ac-675cd9cc44d8.png)
