### PR TITLE
Link toolbar button

### DIFF
--- a/blocks/init/src/Blocks/components/button/components/button-options.js
+++ b/blocks/init/src/Blocks/components/button/components/button-options.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { URLInput } from '@wordpress/block-editor';
 import { ColorPaletteCustom } from '@eightshift/frontend-libs/scripts/components';
 import { SelectControl, TextControl, Icon, ToggleControl } from '@wordpress/components';
 import { icons, getOptionColors, getOptions } from '@eightshift/frontend-libs/scripts/editor';
@@ -19,20 +18,16 @@ export const ButtonOptions = (attributes) => {
 
 		buttonUse = checkAttr('buttonUse', attributes, manifest, componentName),
 
-		buttonUrl = checkAttr('buttonUrl', attributes, manifest, componentName),
 		buttonColor = checkAttr('buttonColor', attributes, manifest, componentName),
 		buttonSize = checkAttr('buttonSize', attributes, manifest, componentName),
 		buttonWidth = checkAttr('buttonWidth', attributes, manifest, componentName),
 		buttonIsAnchor = checkAttr('buttonIsAnchor', attributes, manifest, componentName),
-		buttonIsNewTab = checkAttr('buttonIsNewTab', attributes, manifest, componentName),
 		buttonId = checkAttr('buttonId', attributes, manifest, componentName),
 
-		showButtonUrl = true,
 		showButtonColor = true,
 		showButtonSize = true,
 		showButtonWidth = true,
 		showButtonIsAnchor = true,
-		showButtonIsNewTab = true,
 		showButtonId = true,
 	} = attributes;
 
@@ -57,21 +52,6 @@ export const ButtonOptions = (attributes) => {
 
 			{buttonUse &&
 				<>
-
-					{showButtonUrl &&
-						<URLInput
-							label={
-								<>
-									<Icon icon={icons.link} />
-									{__('URL', 'eightshift-frontend-libs')}
-								</>
-							}
-							value={buttonUrl}
-							autoFocus={false}
-							onChange={(value) => setAttributes({ [`${componentName}Url`]: value })}
-						/>
-					}
-
 					{showButtonColor &&
 						<ColorPaletteCustom
 							label={
@@ -120,14 +100,6 @@ export const ButtonOptions = (attributes) => {
 							checked={buttonIsAnchor}
 							onChange={(value) => setAttributes({ [`${componentName}IsAnchor`]: value })}
 							help={__('Using anchor option will add JavaScript selector to the button. You must provide anchor destination inside Button Url field. Example: #super-block.', 'eightshift-frontend-libs')}
-						/>
-					}
-
-					{showButtonIsNewTab &&
-						<ToggleControl
-							label={__('New Tab', 'eightshift-frontend-libs')}
-							checked={buttonIsNewTab}
-							onChange={(value) => setAttributes({ [`${componentName}IsNewTab`]: value })}
 						/>
 					}
 

--- a/blocks/init/src/Blocks/components/button/components/button-toolbar.js
+++ b/blocks/init/src/Blocks/components/button/components/button-toolbar.js
@@ -3,6 +3,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { AlignmentToolbar } from '@wordpress/block-editor';
 import { checkAttr } from '@eightshift/frontend-libs/scripts/helpers';
 import { getOptions } from '@eightshift/frontend-libs/scripts/editor';
+import { LinkToolbarButton } from '@eightshift/frontend-libs/scripts/components';
+import { useRef } from '@wordpress/element';
 import manifest from './../manifest.json';
 
 export const ButtonToolbar = (attributes) => {
@@ -17,13 +19,18 @@ export const ButtonToolbar = (attributes) => {
 
 		buttonUse = checkAttr('buttonUse', attributes, manifest, componentName),
 		buttonAlign = checkAttr('buttonAlign', attributes, manifest, componentName),
+		buttonUrl = checkAttr('buttonUrl', attributes, manifest, componentName),
+		buttonIsNewTab = checkAttr('buttonIsNewTab', attributes, manifest, componentName),
 
 		showButtonAlign = true,
+		showButtonUrl = true,
 	} = attributes;
 
 	if (!buttonShowControls) {
 		return null;
 	}
+
+	const ref = useRef();
 
 	return (
 		<>
@@ -35,6 +42,18 @@ export const ButtonToolbar = (attributes) => {
 							options={getOptions(manifest, componentName, 'align', options)}
 							label={sprintf(__('%s text align', 'eightshift-frontend-libs'), label)}
 							onChange={(value) => setAttributes({ [`${componentName}Align`]: value })}
+						/>
+					}
+
+					{showButtonUrl &&
+						<LinkToolbarButton
+							componentName={componentName}
+							url={buttonUrl}
+							opensInNewTab={buttonIsNewTab}
+							setAttributes={setAttributes}
+							anchorRef={ref}
+							title={label}
+							textDomain={'eightshift-frontend-libs'}
 						/>
 					}
 				</>

--- a/blocks/init/src/Blocks/components/button/manifest.json
+++ b/blocks/init/src/Blocks/components/button/manifest.json
@@ -4,7 +4,7 @@
 	"componentClass": "btn",
 	"example": {
 		"attributes": {
-			"buttonContent": "This is button",
+			"buttonContent": "This is a button",
 			"buttonUrl": "https://infinum.github.io/eightshift-docs/",
 			"buttonId": "custom ID",
 			"buttonSize": "default",

--- a/blocks/init/src/Blocks/components/link/components/link-options.js
+++ b/blocks/init/src/Blocks/components/link/components/link-options.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { URLInput } from '@wordpress/block-editor';
 import { ColorPaletteCustom } from '@eightshift/frontend-libs/scripts/components';
 import { SelectControl, TextControl, Icon, ToggleControl } from '@wordpress/components';
 import { icons, getOptionColors, getOptions } from '@eightshift/frontend-libs/scripts/editor';
@@ -19,13 +18,11 @@ export const LinkOptions = (attributes) => {
 
 		linkUse = checkAttr('linkUse', attributes, manifest, componentName),
 
-		linkUrl = checkAttr('linkUrl', attributes, manifest, componentName),
 		linkColor = checkAttr('linkColor', attributes, manifest, componentName),
 		linkSize = checkAttr('linkSize', attributes, manifest, componentName),
 		linkIsAnchor = checkAttr('linkIsAnchor', attributes, manifest, componentName),
 		linkId = checkAttr('linkId', attributes, manifest, componentName),
 
-		showLinkUrl = true,
 		showLinkColor = true,
 		showLinkSize = true,
 		showLinkIsAnchor = true,
@@ -54,21 +51,6 @@ export const LinkOptions = (attributes) => {
 
 			{linkUse &&
 				<>
-
-					{showLinkUrl &&
-						<URLInput
-							label={
-								<>
-									<Icon icon={icons.link} />
-									{__('URL', 'eightshift-frontend-libs')}
-								</>
-							}
-							value={linkUrl}
-							autoFocus={false}
-							onChange={(value) => setAttributes({ [`${componentName}Url`]: value })}
-						/>
-					}
-
 					{showLinkColor &&
 						<ColorPaletteCustom
 							label={

--- a/blocks/init/src/Blocks/components/link/components/link-toolbar.js
+++ b/blocks/init/src/Blocks/components/link/components/link-toolbar.js
@@ -3,6 +3,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { AlignmentToolbar } from '@wordpress/block-editor';
 import { checkAttr } from '@eightshift/frontend-libs/scripts/helpers';
 import { getOptions } from '@eightshift/frontend-libs/scripts/editor';
+import { LinkToolbarButton } from '@eightshift/frontend-libs/scripts/components';
+import { useRef } from '@wordpress/element';
 import manifest from '../manifest.json';
 
 export const LinkToolbar = (attributes) => {
@@ -16,15 +18,19 @@ export const LinkToolbar = (attributes) => {
 		linkShowControls = true,
 
 		linkUse = checkAttr('linkUse', attributes, manifest, componentName),
-
 		linkAlign = checkAttr('linkAlign', attributes, manifest, componentName),
+		linkIsNewTab = checkAttr('linkIsNewTab', attributes, manifest, componentName),
+		linkUrl = checkAttr('linkUrl', attributes, manifest, componentName),
 
 		showLinkAlign = true,
+		showLinkUrl = true,
 	} = attributes;
 
 	if (!linkShowControls) {
 		return null;
 	}
+
+	const ref = useRef();
 
 	return (
 		<>
@@ -36,6 +42,18 @@ export const LinkToolbar = (attributes) => {
 							options={getOptions(manifest, componentName, 'align', options)}
 							label={sprintf(__('%s text align', 'eightshift-frontend-libs'), label)}
 							onChange={(value) => setAttributes({ [`${componentName}Align`]: value })}
+						/>
+					}
+
+					{showLinkUrl &&
+						<LinkToolbarButton
+							componentName={componentName}
+							url={linkUrl}
+							opensInNewTab={linkIsNewTab}
+							setAttributes={setAttributes}
+							anchorRef={ref}
+							title={label}
+							textDomain={'eightshift-frontend-libs'}
 						/>
 					}
 				</>

--- a/scripts/components/index.js
+++ b/scripts/components/index.js
@@ -4,3 +4,4 @@ export { Responsive } from './responsive/responsive';
 export { HelpModal } from './help-modal/help-modal';
 export { CustomSelect } from './custom-select/custom-select';
 export { ServerSideRender } from './server-side-render/server-side-render';
+export { LinkToolbarButton } from './link-toolbar-button/link-toolbar-button';

--- a/scripts/components/link-toolbar-button/docs/readme.mdx
+++ b/scripts/components/link-toolbar-button/docs/readme.mdx
@@ -5,7 +5,7 @@ A toolbar button that allows link selection, just like stock Gutenberg controls.
 ## Usage
 
 To use it:
-1. Import the component
+1. Import the component from Frontend Libs
 2. Import `useRef` and create a reference
 3. Add the `LinkToolbarButton` into the toolbar
 
@@ -32,6 +32,7 @@ export const ButtonToolbar = (attributes) =>  {
 				setAttributes={setAttributes}
 				anchorRef={ref}
 				title={label}
+				textDomain={'eightshift-frontend-libs'}
 			/>
 	)
 }

--- a/scripts/components/link-toolbar-button/docs/readme.mdx
+++ b/scripts/components/link-toolbar-button/docs/readme.mdx
@@ -1,0 +1,38 @@
+# LinkToolbarButton
+
+A toolbar button that allows link selection, just like stock Gutenberg controls.
+
+## Usage
+
+To use it:
+1. Import the component
+2. Import `useRef` and create a reference
+3. Add the `LinkToolbarButton` into the toolbar
+
+```jsx
+import { LinkToolbarButton } from '@eightshift/frontend-libs/scripts/components';
+import { useRef } from '@wordpress/element';
+
+// ...
+
+export const ButtonToolbar = (attributes) =>  {
+	// ...
+
+	const ref = useRef();
+
+	// ...
+
+	return (
+			// ...
+
+			<LinkToolbarButton
+				componentName={componentName}
+				url={buttonUrl}
+				opensInNewTab={buttonOpensInNewTab}
+				setAttributes={setAttributes}
+				anchorRef={ref}
+				title={label}
+			/>
+	)
+}
+```

--- a/scripts/components/link-toolbar-button/docs/story.js
+++ b/scripts/components/link-toolbar-button/docs/story.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import readme from './readme.mdx';
+import { useRef, useState } from '@wordpress/element';
+import { LinkToolbarButton } from '@eightshift/frontend-libs/scripts/components/link-toolbar-button/link-toolbar-button';
+
+export default {
+	title: 'Options/LinkToolbarButton',
+	parameters: {
+		docs: {
+			page: readme
+		}
+	},
+};
+
+export const component = () => {
+	const ref = useRef();
+	const [objData, setObjData] = useState({
+		url: '',
+		newTab: false,
+	});
+
+	return (<LinkToolbarButton
+		componentName={'dummy-component'}
+		url={objData.url}
+		opensInNewTab={objData.newTab}
+		setAttributes={setObjData}
+		anchorRef={ref}
+		title={'Dummy component'}
+		textDomain={'TestDomain'}
+	/>);
+}

--- a/scripts/components/link-toolbar-button/link-toolbar-button.js
+++ b/scripts/components/link-toolbar-button/link-toolbar-button.js
@@ -21,7 +21,7 @@ export const LinkToolbarButton = ({
 	};
 
 	const urlAttribute = `${componentName}Url`;
-	const opensInNewTabAttribute = `${componentName}OpensInNewTab`;
+	const opensInNewTabAttribute = `${componentName}IsNewTab`;
 
 	const unlinkButton = () => {
 		setAttributes({

--- a/scripts/components/link-toolbar-button/link-toolbar-button.js
+++ b/scripts/components/link-toolbar-button/link-toolbar-button.js
@@ -1,0 +1,85 @@
+import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
+import { link, linkOff } from '@wordpress/icons';
+import { Popover, Button, ToolbarButton } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+export const LinkToolbarButton = ({
+	componentName,
+	url,
+	opensInNewTab,
+	setAttributes,
+	anchorRef,
+	title,
+	textDomain = ''
+}) => {
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+	const openLinkControl = () => {
+		setIsDropdownOpen(true);
+		return false; // Prevents default behaviour for event.
+	};
+
+	const urlAttribute = `${componentName}Url`;
+	const opensInNewTabAttribute = `${componentName}OpensInNewTab`;
+
+	const unlinkButton = () => {
+		setAttributes({
+			[urlAttribute]: undefined,
+			[opensInNewTabAttribute]: undefined,
+		});
+		setIsDropdownOpen(false);
+	};
+
+	const linkControl = isDropdownOpen && (
+		<Popover
+			position='bottom center'
+			onClose={() => setIsDropdownOpen(false)}
+			anchorRef={anchorRef?.current}
+		>
+			<LinkControl
+				value={{ url, opensInNewTab }}
+				settings={
+					[
+						{
+							id: 'opensInNewTab',
+							title: __('Open in new tab', textDomain),
+						}
+					]
+				}
+				onChange={({
+					url: newUrl = '',
+					opensInNewTab: newTab,
+				}) => {
+					setAttributes({
+						[urlAttribute]: newUrl,
+						[opensInNewTabAttribute]: newTab
+					});
+				}}
+			/>
+			<div style={{ padding: '1rem' }}>
+				<Button
+					onClick={unlinkButton}
+					isDestructive={true}
+					icon={linkOff}
+				>
+					{__('Remove link', textDomain)}
+				</Button>
+			</div>
+		</Popover>
+	);
+	return (
+		<>
+			<ToolbarButton
+				name="link"
+				icon={link}
+				title={sprintf(__('%s URL', textDomain), title)}
+				onClick={openLinkControl}
+				isActive={url?.length}
+			/>
+			{linkControl}
+		</>
+	);
+}
+
+export default LinkToolbarButton;


### PR DESCRIPTION
Closes #181.

This PR replaces the ugly old `URLInput` in the option with the fresh new `LinkInput`. As `LinkInput` itself wasn't meant to be used in an option panel, the URL picker now lies in the block toolbar (just like in stock Gutenberg).

To easily accomplish this (as there are a few elements to handle), a custom component - `LinkToolbarButton` - was created.

To use it in your blocks:
1. Import the component from FL
2. Import `useRef` and create a reference before the return function of your component
3. Add the `LinkToolbarButton` into the toolbar

Use it like this:
```jsx
<LinkToolbarButton
	componentName={componentName}
	url={buttonUrl}
	opensInNewTab={buttonOpensInNewTab}
	setAttributes={setAttributes}
	anchorRef={ref}
	title={label}
/>
```

In the editor it looks like this:
![image](https://user-images.githubusercontent.com/77000136/114900181-eb0d0b80-9e13-11eb-825c-c33519eb379d.png)
![image](https://user-images.githubusercontent.com/77000136/114900225-f5c7a080-9e13-11eb-9068-6177cb9319eb.png)




