### PR TITLE
Icon new picker (and more CustomSelect goodies)

### DIFF
--- a/blocks/init/src/Blocks/components/icon/components/icon-options.js
+++ b/blocks/init/src/Blocks/components/icon/components/icon-options.js
@@ -9,16 +9,14 @@ import manifest from './../manifest.json';
 
 const { icons } = manifest;
 
-const IconPickerOption = props => {
-	return (
-		<components.Option {...props}>
-			<div className={'icon-option-row'}>
-				<i dangerouslySetInnerHTML={{ __html: icons[props.value] }}></i>
-				<span>{props.label}</span>
-			</div>
-		</components.Option>
-	);
-};
+const IconPickerOption = props => (
+	<components.Option {...props}>
+		<div className={'icon-option-row'}>
+			<i dangerouslySetInnerHTML={{ __html: icons[props.value] }}></i>
+			<span>{props.label}</span>
+		</div>
+	</components.Option>
+);
 
 const IconPickerValueDisplay = ({ children, ...props }) => (
 	<components.SingleValue {...props}>

--- a/blocks/init/src/Blocks/components/icon/components/icon-options.js
+++ b/blocks/init/src/Blocks/components/icon/components/icon-options.js
@@ -1,8 +1,33 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import { __, sprintf } from '@wordpress/i18n';
-import { SelectControl, ToggleControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { checkAttr } from '@eightshift/frontend-libs/scripts/helpers';
+import { CustomSelect } from '@eightshift/frontend-libs/scripts/components';
+import { components } from 'react-select';
+
 import manifest from './../manifest.json';
+
+const { icons } = manifest;
+
+const IconPickerOption = props => {
+	return (
+		<components.Option {...props}>
+			<div className={'icon-option-row'}>
+				<i dangerouslySetInnerHTML={{ __html: icons[props.value] }}></i>
+				<span>{props.label}</span>
+			</div>
+		</components.Option>
+	);
+};
+
+const IconPickerValueDisplay = ({ children, ...props }) => (
+	<components.SingleValue {...props}>
+		<div className={'icon-option-row'}>
+			<i dangerouslySetInnerHTML={{ __html: icons[props.data.value] }}></i>
+			<span>{children}</span>
+		</div>
+	</components.SingleValue>
+);
 
 export const IconOptions = (attributes) => {
 	const { options, title } = manifest;
@@ -12,7 +37,7 @@ export const IconOptions = (attributes) => {
 		componentName = manifest.componentName,
 		label = title,
 		iconUse = checkAttr('iconUse', attributes, manifest, componentName),
-		iconName = checkAttr('iconName', attributes, manifest, componentName),
+		iconSelectedIcon = checkAttr('iconSelectedIcon', attributes, manifest, componentName),
 		showIconOptions = true,
 	} = attributes;
 
@@ -31,13 +56,24 @@ export const IconOptions = (attributes) => {
 			/>
 
 			{iconUse && (
-				<SelectControl
+				<CustomSelect
 					label={__('Icon', 'eightshift-frontend-libs')}
-					value={iconName}
+					value={iconSelectedIcon}
 					options={options.icons}
-					onChange={(value) => setAttributes({ [`${componentName}Name`]: value })}
+					placeholder={__('Select an icon', 'eightshift-frontend-libs')}
+					customOptionComponent={IconPickerOption}
+					customSingleValueDisplayComponent={IconPickerValueDisplay}
+					onChange={(value) => (
+						// Because react-select needs an object instead
+						// of a label for storing data, this approach was
+						// taken to prevent breaking everything that
+						// currently uses an icon
+						setAttributes({
+							[`${componentName}SelectedIcon`]: value,
+							[`${componentName}Name`]: value?.value,
+						})
+					)}
 				/>
-
 			)}
 		</>
 	);

--- a/blocks/init/src/Blocks/components/icon/icon-editor.scss
+++ b/blocks/init/src/Blocks/components/icon/icon-editor.scss
@@ -1,0 +1,17 @@
+.icon-option-row {
+	display: grid;
+	align-items: center;
+	grid-template-columns: 0.6rem 1fr;
+	grid-gap: 1rem;
+
+	i {
+		margin: 0;
+		padding: 0;
+
+		svg {
+			width: 1.2rem;
+			height: 1.2rem;
+			transform: translateY(2px);
+		}
+	}
+}

--- a/blocks/init/src/Blocks/components/icon/manifest.json
+++ b/blocks/init/src/Blocks/components/icon/manifest.json
@@ -13,6 +13,10 @@
 			"type": "string",
 			"default": "play"
 		},
+		"iconSelectedIcon": {
+			"type": "object",
+			"default": null
+		},
 		"iconUse": {
 			"type": "boolean",
 			"default": true

--- a/scripts/components/custom-select/custom-select.js
+++ b/scripts/components/custom-select/custom-select.js
@@ -21,6 +21,8 @@ export const CustomSelect = (props) => {
 		loadOptions,
 		placeholder,
 		sortAxis = 'y',
+		customOptionComponent,
+		customSingleValueDisplayComponent,
 	} = props;
 
 	const isSynchronous = !loadOptions;
@@ -31,6 +33,14 @@ export const CustomSelect = (props) => {
 		array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0]);
 		return array;
 	}
+
+	const Option = (props) => {
+		return <components.Option {...props} />;
+	};
+
+	const SingleValue = (props) => {
+		return <components.SingleValue {...props} />;
+	};
 
 	const SortableMultiValue = SortableElement((propsSortable) => {
 
@@ -128,7 +138,9 @@ export const CustomSelect = (props) => {
 				isClearable={isClearable}
 				components={{
 					MultiValue: SortableMultiValue,
-					MultiValueLabel: SortableMultiValueLabel
+					MultiValueLabel: SortableMultiValueLabel,
+					Option: customOptionComponent ?? Option,
+					SingleValue: customSingleValueDisplayComponent ?? SingleValue,
 				}}
 				closeMenuOnSelect={closeMenuOnSelect}
 				theme={(theme) => ({

--- a/scripts/components/custom-select/docs/readme.mdx
+++ b/scripts/components/custom-select/docs/readme.mdx
@@ -20,6 +20,8 @@ there are some properties common to both and some that differ between sync/async
 | `isSearchable` | _(optional)_ If `true` allows searching through the results. Default: `true`. |
 | `placeholder` | _(optional)_ When no items are selected, the placeholder text is shown if set. |
 | `sortAxis` | _(optional)_ If multiple items are selected, this option sets the allowed sorting axis. Default is `y`. Allowed options: `x`, `y`, `xy`. |
+| `customOptionComponent` | _(optional)_ Component that renders a dropdown option. |
+| `customSingleValueDisplayComponent` | _(optional)_ Component that renders the label of the currently selected item. Doesn't apply to multi-value selects. |
 
 ### When used as a synchronous select
 | Property | Description |
@@ -81,5 +83,54 @@ there are some properties common to both and some that differ between sync/async
 	onChange={(value) => setAttributes({ myValue: value })}
 	multiple={true}
 	label={__('My label', 'eigthshift-frontend-libs')}
+/>
+```
+
+## Implementing a custom dropdown/value display
+
+It's easy as 1-2-3!
+
+### 1) Import `react-select` components
+```jsx
+import { components } from 'react-select';
+```
+
+### 2) Create your custom component
+
+#### Dropdown option
+
+```jsx
+const CustomPickerOption = props => {
+	return (
+		<components.Option {...props}>
+			<span>👉 {props.label}</span>
+		</components.Option>
+	);
+};
+```
+
+Use `props.label` to get the current item's label and `props.value` for the value.
+
+
+#### Value display
+
+```jsx
+const CustomValueDisplay = ({ children, ...props }) => (
+	<components.SingleValue {...props}>
+		<span>👉 {children}</span>
+	</components.SingleValue>
+);
+```
+
+Use `props.data.label` or `children` to get the current item's label and `props.data.value` for the value.
+
+### 3) Pass it to your `CustomSelect`
+
+```jsx
+<CustomSelect
+	// ...
+	customOptionComponent={IconPickerOption}
+	customSingleValueDisplayComponent={IconPickerValueDisplay}
+	// ...
 />
 ```

--- a/scripts/components/custom-select/docs/story.js
+++ b/scripts/components/custom-select/docs/story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import readme from './readme.mdx';
 import { CustomSelect } from '../custom-select';
+import { components } from 'react-select';
 
 export default {
 	title: 'Options/Custom Select',
@@ -65,6 +66,24 @@ const getSearchableData = (inputValue) => {
 	})
 };
 
+const CustomPickerOption = props => (
+	<components.Option {...props}>
+		<div>
+			<span role='img' aria-label='pointing to the right'>👉 &nbsp;</span>
+			<span>{props.label}</span>
+		</div>
+	</components.Option>
+);
+
+const CustomValueDisplay = ({ children, ...props }) => (
+	<components.SingleValue {...props}>
+		<div>
+			<span role='img' aria-label='pointing to the right'>👉 &nbsp;</span>
+			<span>{children}</span>
+		</div>
+	</components.SingleValue>
+);
+
 export const SelectSingle = () => {
 	return (
 		<CustomSelect
@@ -119,5 +138,49 @@ export const AsyncSelectMultipleWithRefetch = () => {
 			loadOptions={getSearchableData}
 			reFetchOnSearch={true}
 		/>
+	)
+};
+
+export const CustomRendering = () => {
+	return (
+		<>
+			<p>Custom dropdown items</p>
+			<CustomSelect
+				{...defaultProps}
+				multiple={false}
+				label={'My cool single select menu'}
+				customOptionComponent={CustomPickerOption}
+				options={data}
+			/>
+
+			<p>Custom value label</p>
+			<CustomSelect
+				{...defaultProps}
+				multiple={false}
+				label={'My cool single select menu'}
+				customSingleValueDisplayComponent={CustomValueDisplay}
+				options={data}
+			/>
+
+			<p>Custom dropdown items and value label</p>
+			<CustomSelect
+				{...defaultProps}
+				multiple={false}
+				label={'My cool single select menu'}
+				customOptionComponent={CustomPickerOption}
+				customSingleValueDisplayComponent={CustomValueDisplay}
+				options={data}
+			/>
+
+
+			<p>Custom dropdown items on multi-select menu</p>
+			<CustomSelect
+				{...defaultProps}
+				multiple={true}
+				label={'My cool multiple select menu'}
+				customOptionComponent={CustomPickerOption}
+				options={data}
+			/>
+		</>
 	)
 };


### PR DESCRIPTION
This PR brings 2 new things:
1. A way to render custom dropdown item and (single) value display components in `CustomSelect`
2. Enabled by 1., a new icon picker for the `icon` component (demo below)

https://user-images.githubusercontent.com/77000136/116115880-d30e7500-a6ba-11eb-8157-ca7c4ed1bf17.mov

More details in the Storybook documentation.



