### PR TITLE
Optional undefinedAllowed parameter on checkAttr

### DIFF
--- a/scripts/helpers/check-attr.js
+++ b/scripts/helpers/check-attr.js
@@ -7,41 +7,46 @@ import _ from 'lodash';
  * @param {array}  attributes Array of attributes.
  * @param {object}  manifest Array of default attributes from manifest.json.
  * @param {string} componentName The real component name.
+ * @param {boolean} undefinedAllowed Allowed detection of undefined values.
  *
  * @return mixed
  */
-export const checkAttr = (key, attributes, manifest, componentName = '') => {
+export const checkAttr = (key, attributes, manifest, componentName = '', undefinedAllowed = false) => {
 
 	if (Object.prototype.hasOwnProperty.call(attributes, key)) {
 		return attributes[key];
-	} else {
-		const manifestKey = manifest.attributes[key];
+	} 
 
-		if (typeof manifestKey === 'undefined') {
-			throw Error(`${key} key does not exist in the ${componentName} component. Please check your implementation.`);
-		}
+	const manifestKey = manifest.attributes[key];
 
-		const defaultType = manifestKey.type;
-
-		let defaultValue;
-
-		switch (defaultType) {
-			case 'boolean':
-				defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : false;
-				break;
-			case 'array':
-				defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : [];
-				break;
-			case 'object':
-				defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : {};
-				break;
-			default:
-				defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : '';
-				break;
-		}
-
-		return defaultValue;
+	if (typeof manifestKey === 'undefined') {
+		throw Error(`${key} key does not exist in the ${componentName} component. Please check your implementation.`);
 	}
+
+	if (!Object.prototype.hasOwnProperty.call(manifestKey, 'default') && undefinedAllowed) {
+		return undefined;
+	}
+
+	const defaultType = manifestKey.type;
+
+	let defaultValue;
+
+	switch (defaultType) {
+		case 'boolean':
+			defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : false;
+			break;
+		case 'array':
+			defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : [];
+			break;
+		case 'object':
+			defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : {};
+			break;
+		default:
+			defaultValue = Object.prototype.hasOwnProperty.call(manifestKey, 'default') ? manifestKey.default : '';
+			break;
+	}
+
+	return defaultValue;
 };
 
 /**
@@ -51,10 +56,11 @@ export const checkAttr = (key, attributes, manifest, componentName = '') => {
  * @param {array}  attributes Array of attributes.
  * @param {object} manifest Array of default attributes from manifest.json.
  * @param {string} componentName The real component name.
+ * @param {boolean} undefinedAllowed Allowed detection of undefined values.
  *
  * @returns mixed
  */
-export const checkAttrResponsive = (keyName, attributes, manifest, componentName = '') => {
+export const checkAttrResponsive = (keyName, attributes, manifest, componentName = '', undefinedAllowed = false) => {
 	const output = {};
 
 	if (! _.has(manifest, 'responsiveAttributes')) {
@@ -66,7 +72,7 @@ export const checkAttrResponsive = (keyName, attributes, manifest, componentName
 	}
 
 	for (const [key, value] of Object.entries(manifest.responsiveAttributes[keyName])) {
-		output[key] = checkAttr(value, attributes, manifest, componentName);
+		output[key] = checkAttr(value, attributes, manifest, componentName, undefinedAllowed);
 	}
 	
 	return output;


### PR DESCRIPTION
Changelog:
- check-attr.js
  - added optional undefinedAllowed parameter on checkAttr function
  - removed else hance early exit

In admin options, while creating responsive attributes it appeared that we can't "force" attributes to unset the value so it can inherit from other breakpoints. That's why I added this optional parameter which can be used if it is ok for you to set values to `undefined`.

This change is only important on the admin side while setting the attributes. I believe that there is no need to make these changes on PHP part(eightshift-libs). However, if you feel like we should make it exactly the same, feel free to write to me or comment down here on PR.

Screen Shots and Screen Recordings of the use case scenario

<img width="921" alt="JS additional parameter" src="https://user-images.githubusercontent.com/46056662/118799692-50369f80-b89f-11eb-8e6c-bae5c7b2def9.png">
<img width="725" alt="third state of toggle" src="https://user-images.githubusercontent.com/46056662/118799697-52006300-b89f-11eb-87a4-1fc7865ce945.png">

https://user-images.githubusercontent.com/46056662/118799704-53319000-b89f-11eb-9cdd-adda731fa09b.mov

<img width="577" alt="detection of undefined for button" src="https://user-images.githubusercontent.com/46056662/118799737-5cbaf800-b89f-11eb-9455-0e06acea627a.png">

