### PR TITLE
Add variablesEditor to Manifest

### DIFF
--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -109,6 +109,7 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 	// Define variables from manifest.
 	const {
 		variables,
+		variablesEditor,
 	} = manifest;
 
 	// Get the initial data array.
@@ -117,49 +118,61 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 	// Check if component or block.
 	let name = manifest['componentClass'] ?? attributes['blockClass'];
 
-	// Iterate each variable.
-	for (const [variableName, variableValue] of Object.entries(variables)) {
 
-		// Constant for attributes set value (in db or default).
-		const attributeValue = attributes[variableName];
+	// Setting defined variables to each breakpoint.
+	const setVariablesToBreakpoints = (variables) => {
+		// Iterate each variable.
+		for (const [variableName, variableValue] of Object.entries(variables)) {
 
-		// Set internal breakpoints variable.
-		let internalBreakpoints = [];
+			// Constant for attributes set value (in db or default).
+			const attributeValue = attributes[variableName];
 
-		// If type default or value.
-		if (!Array.isArray(variableValue)) {
-			internalBreakpoints = variableValue[attributeValue] ?? [];
-		} else {
-			internalBreakpoints = variableValue;
-		}
+			// Set internal breakpoints variable.
+			let internalBreakpoints = [];
 
-		// Iterate variable array to check breakpoints.
-		internalBreakpoints.forEach((breakpointItem) => {
+			// If type default or value.
+			if (!Array.isArray(variableValue)) {
+				internalBreakpoints = variableValue[attributeValue] ?? [];
+			} else {
+				internalBreakpoints = variableValue;
+			}
 
-			// Define variables from breakpointItem.
-			const {
-				breakpoint = 'default', // If breakpoint is not set use default name
-				inverse = false, // If inverse is not set use mobile first.
-				variable = [],
-			} = breakpointItem;
+			// Iterate variable array to check breakpoints.
+			internalBreakpoints.forEach((breakpointItem) => {
 
-			// Check if we are using mobile or desktop first. Mobile first is the default.
-			const type = inverse ? 'max' : 'min';
+				// Define variables from breakpointItem.
+				const {
+					breakpoint = 'default', // If breakpoint is not set use default name
+					inverse = false, // If inverse is not set use mobile first.
+					variable = [],
+				} = breakpointItem;
 
-			// Iterate each data array to find the correct breakpoint.
-			data.some((item, index) => {
+				// Check if we are using mobile or desktop first. Mobile first is the default.
+				const type = inverse ? 'max' : 'min';
 
-				// Check if breakpoint and type match.
-				if (item.name === breakpoint && item.type === type) {
+				// Iterate each data array to find the correct breakpoint.
+				data.some((item, index) => {
 
-					// Merge data variables with the new variables array.
-					data[index].variable = item.variable.concat(variablesInner(variable, attributeValue));
+					// Check if breakpoint and type match.
+					if (item.name === breakpoint && item.type === type) {
 
-					// Exit.
-					return true;
-				}
+						// Merge data variables with the new variables array.
+						data[index].variable = item.variable.concat(variablesInner(variable, attributeValue));
+
+						// Exit.
+						return true;
+					}
+				});
 			});
-		});
+		}
+	}
+
+	// Iterate each variable from variables field.
+	setVariablesToBreakpoints(variables);
+
+	if (variablesEditor) {
+		// Iterate each variable from variablesEditor field.
+		setVariablesToBreakpoints(variablesEditor);
 	}
 
 	// Loop data and provide correct selectors from data array.
@@ -194,7 +207,7 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 
 	// Output manual output from the array of variables.
 	const manual = _.has(manifest, 'variablesCustom') ? manifest['variablesCustom'].join(';\n') : '';
-	const manualEditor = _.has(manifest, 'variablesEditor') ? manifest['variablesEditor'].join(';\n') : '';
+	const manualEditor = _.has(manifest, 'variablesCustomEditor') ? manifest['variablesCustomEditor'].join(';\n') : '';
 
 	// Prepare final output for testing.
 	const fullOutput = `


### PR DESCRIPTION
Changelog:
- added CSS variables(variablesEditor) for only editor use
- renamed general editor only variables to variablesCustomEditor

Usage:
When there is a specific behavior that you want to override in the editor part, but keep everything in place for frontend part.
An example of behavior is under screenshots and screenrecording.

How to:
It behaves exactly the same as `variables` key from manifest. It will always override the `variables` with the same "key" because it's outputting afterward.
![Screen Shot 2021-05-28 at 4 20 47 PM](https://user-images.githubusercontent.com/46056662/119998097-ac50a080-bfd0-11eb-823f-ff8e566f78ae.png)


Screenshots and screenrecording:
https://user-images.githubusercontent.com/46056662/119996776-58918780-bfcf-11eb-9ea4-d635e349bfb1.mov
<img width="516" alt="Screen Shot 2021-05-28 at 4 13 50 PM" src="https://user-images.githubusercontent.com/46056662/119997153-b4f4a700-bfcf-11eb-87ff-41c18956d511.png">
