### PR TITLE
Fix props logic

### DIFF
--- a/scripts/editor/props.js
+++ b/scripts/editor/props.js
@@ -25,17 +25,17 @@ export const props = (attributes, realName, newName = '', isBlock = false, names
 	// Get global window data.
 	const globalData = window['eightshift'][namespace].dependency;
 
-	// If component use components dependency tree.
-	// Add the current component name to the dependency array.
-	let dependency = [
-		...globalData.components[realName],
-		newNameInternal
-	];
+	let dependency = [];
 
-	// If block use blocks dependency tree.
+	// If block use blocks dependency tree, if component use components dependency tree.
 	if (isBlock) {
 		dependency = globalData.blocks[realName];
+	} else {
+		dependency = globalData.components[realName];
 	}
+
+	// Add the current component name to the dependency array.
+	dependency.push(newNameInternal);
 
 	// If you have multiple components just use one.
 	dependency = _.uniq(dependency);

--- a/scripts/editor/props.js
+++ b/scripts/editor/props.js
@@ -27,7 +27,7 @@ export const props = (attributes, realName, newName = '', isBlock = false, names
 
 	let dependency = [];
 
-	// If block use blocks dependency tree, if component use components dependency tree.
+	// If isBlock use block's dependency tree, if component use component's dependency tree.
 	if (isBlock) {
 		dependency = globalData.blocks[realName];
 	} else {

--- a/scripts/editor/props.js
+++ b/scripts/editor/props.js
@@ -27,7 +27,7 @@ export const props = (attributes, realName, newName = '', isBlock = false, names
 
 	let dependency = [];
 
-	// If isBlock use block's dependency tree, if component use component's dependency tree.
+	// If it's a block, use the block's dependency tree. If it's a component, use the component's dependency tree.
 	if (isBlock) {
 		dependency = globalData.blocks[realName];
 	} else {


### PR DESCRIPTION
Fixed a bug where props would throw a warning if you had a block (let's say `example`) but you don't have an `example` component in your project.