### PR TITLE
Responsive variables

### DIFF
--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -162,6 +162,8 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 						// Exit.
 						return true;
 					}
+
+					return false;
 				});
 			});
 		}
@@ -259,7 +261,7 @@ const setBreakpointResponsiveVariables = (attributeVariables, breakpointName, br
 		return {
 			...attributeVariablesObject,
 			breakpoint: breakpointIndex === defaultBreakpointIndex ? 'default' : breakpointName,
-		};;
+		};
 	})
 }
 

--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -73,6 +73,83 @@ export const globalInner = (itemValues, itemKey) => {
 }
 
 /**
+ * Sets up a breakpoint value to responsive attribute objects from responsiveAttribute object.
+ *
+ * @param {array}  attributeVariables  - Array of attribute variables object.
+ * @param {string} breakpointName    	 - Breakpoint name from responsiveAttribute's breakpoint in block's/component's manifest.
+ * @param {number} breakpointIndex   	 - Index of responsiveAttribute's breakpoint in manifest.
+ * @param {number} numberOfBreakpoints - Number of responsiveAttribute breakpoints in block's/component's manifest.
+ *
+ * @return {array}
+ */
+const setBreakpointResponsiveVariables = (attributeVariables, breakpointName, breakpointIndex, numberOfBreakpoints) => {
+	return attributeVariables.map((attributeVariablesObject) => {
+
+		// Calculate default breakpoint index based on order of the breakpoint, inverse property and number of properties in responsiveAttributeObject.
+		const defaultBreakpointIndex = attributeVariablesObject.inverse ? 0 : (numberOfBreakpoints - 1);
+
+		// Expanding an object with an additional breakpoint property.
+		return {
+			...attributeVariablesObject,
+			breakpoint: breakpointIndex === defaultBreakpointIndex ? 'default' : breakpointName,
+		};
+	})
+}
+
+/**
+ * Iterating through variables matching the keys from responsiveAttributes and translating it to responsive attributes names.
+ *
+ * @param {object} responsiveAttributes - Responsive attributes that are read from component's/block's manifest.
+ * @param {object} variables            - Object containing objects with component's/block's attribute variables that are read from manifest.
+ *
+ * @return {object} Object prepared for setting all the variables to its breakpoints.
+ */
+const setupResponsiveVariables = (responsiveAttributes, variables) => {
+	// Iterate through responsive attributes.
+	return Object.entries(responsiveAttributes).reduce((responsiveAttributesVariables, [responsiveAttributeName, responsiveAttributeObject]) => {
+
+		// If responsive attribute doesn't exist in variables object, skip it
+		if (!responsiveAttributeName || _.isEmpty(variables[responsiveAttributeName])) {
+			return responsiveAttributesVariables;
+		}
+
+		// Used for determination of default breakpoint.
+		const numberOfBreakpoints = Object.entries(responsiveAttributeObject).length;
+
+		// Iterate each responsive attribute object as breakpoint name is the key of the object, and value represents the name of the responsive variable.
+		const responsiveAttributeVariables = Object.entries(responsiveAttributeObject).reduce((responsiveAttribute, [breakpointName, breakpointVariableName], breakpointIndex) => {
+			let breakpointVariables = {};
+
+			// Array represents direct value(default or value).
+			if (Array.isArray(variables[responsiveAttributeName])) {
+				breakpointVariables = setBreakpointResponsiveVariables(variables[responsiveAttributeName], breakpointName, breakpointIndex, numberOfBreakpoints);
+
+			// Object treatment goes depending on a value inserted(multiple choice, boolean or similar).
+			} else {
+
+				// Iterate options/multiple choices/boolean...
+				breakpointVariables = Object.entries(variables[responsiveAttributeName])
+				.reduce((acc, [attributeValue, attributeObject]) => {
+					return {
+						...acc,
+						[attributeValue]: setBreakpointResponsiveVariables(attributeObject, breakpointName, breakpointIndex, numberOfBreakpoints),
+					}
+				}, {});
+			}
+
+			// Collect all the values from one responsive attribute to one object.
+			return {
+				...responsiveAttribute,
+				[breakpointVariableName]: breakpointVariables,
+			};
+		}, {});
+
+		// Merge multiple responsive attributes to one object.
+		return {...responsiveAttributesVariables, ...responsiveAttributeVariables};
+	}, {});
+}
+
+/**
  * Setting defined variables to each breakpoint.
  *
  * @param {object} attributes - Attributes fetched from manifest.
@@ -250,72 +327,6 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 
 	// Output the style for CSS variables.
 	return <style dangerouslySetInnerHTML={{__html: `${output} ${finalManualOutput}`}}></style>;
-}
-
-/**
- * Sets up a breakpoint value to responsive attribute objects from responsiveAttribute object.
- *
- * @param {array}  attributeVariables  - Array of attribute variables object.
- * @param {string} breakpointName    	 - Breakpoint name from responsiveAttribute's breakpoint in block's/component's manifest.
- * @param {number} breakpointIndex   	 - Index of responsiveAttribute's breakpoint in manifest.
- * @param {number} numberOfBreakpoints - Number of responsiveAttribute breakpoints in block's/component's manifest.
- *
- * @return {array}
- */
-const setBreakpointResponsiveVariables = (attributeVariables, breakpointName, breakpointIndex, numberOfBreakpoints) => {
-	return attributeVariables.map((attributeVariablesObject) => {
-		// Calculate default breakpoint index.
-		const defaultBreakpointIndex = attributeVariablesObject.inverse ? 0 : (numberOfBreakpoints - 1);
-
-		return {
-			...attributeVariablesObject,
-			breakpoint: breakpointIndex === defaultBreakpointIndex ? 'default' : breakpointName,
-		};
-	})
-}
-
-/**
- * Iterating through variables matching the keys from responsiveAttributes and translating it to responsive attributes names.
- *
- * @param {object} responsiveAttributes - Responsive attributes that are read from component's/block's manifest.
- * @param {object} variables            - Object containing objects with component's/block's attribute variables that are read from manifest.
- *
- * @return {object} Object prepared for setting all the variables to its breakpoints.
- */
-export const setupResponsiveVariables = (responsiveAttributes, variables) => {
-	return Object.entries(responsiveAttributes).reduce((responsiveAttributesVariables, [responsiveAttributeName, responsiveAttributeObject]) => {
-		if (!responsiveAttributeName || _.isEmpty(variables[responsiveAttributeName])) {
-			return responsiveAttributesVariables;
-		}
-
-		// To be able to determine default breakpoint.
-		const numberOfBreakpoints = Object.entries(responsiveAttributeObject).length;
-		const responsiveAttributeVariables = Object.entries(responsiveAttributeObject).reduce((responsiveAttribute, [breakpointName, breakpointVariableName], breakpointIndex) => {
-			let breakpointVariables = {};
-
-			// Array treatment goes directly.
-			if (Array.isArray(variables[responsiveAttributeName])) {
-				breakpointVariables = setBreakpointResponsiveVariables(variables[responsiveAttributeName], breakpointName, breakpointIndex, numberOfBreakpoints);
-
-				// Object treatment goes depending on a value inserted.
-			} else {
-				breakpointVariables = Object.entries(variables[responsiveAttributeName])
-				.reduce((acc, [attributeValue, attributeObject]) => {
-					return {
-						...acc,
-						[attributeValue]: setBreakpointResponsiveVariables(attributeObject, breakpointName, breakpointIndex, numberOfBreakpoints),
-					}
-				}, {});
-			}
-
-			return {
-				...responsiveAttribute,
-				[breakpointVariableName]: breakpointVariables,
-			};
-		}, {});
-
-		return {...responsiveAttributesVariables, ...responsiveAttributeVariables};
-	}, {});
 }
 
 /**

--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -106,47 +106,56 @@ const setBreakpointResponsiveVariables = (attributeVariables, breakpointName, br
  */
 const setupResponsiveVariables = (responsiveAttributes, variables) => {
 	// Iterate through responsive attributes.
-	return Object.entries(responsiveAttributes).reduce((responsiveAttributesVariables, [responsiveAttributeName, responsiveAttributeObject]) => {
+	return Object.entries(responsiveAttributes)
+		.reduce((responsiveAttributesVariables, [responsiveAttributeName, responsiveAttributeObject]) => {
 
-		// If responsive attribute doesn't exist in variables object, skip it
-		if (!responsiveAttributeName || _.isEmpty(variables[responsiveAttributeName])) {
-			return responsiveAttributesVariables;
-		}
-
-		// Used for determination of default breakpoint.
-		const numberOfBreakpoints = Object.entries(responsiveAttributeObject).length;
-
-		// Iterate each responsive attribute object as breakpoint name is the key of the object, and value represents the name of the responsive variable.
-		const responsiveAttributeVariables = Object.entries(responsiveAttributeObject).reduce((responsiveAttribute, [breakpointName, breakpointVariableName], breakpointIndex) => {
-			let breakpointVariables = {};
-
-			// Array represents direct value(default or value).
-			if (Array.isArray(variables[responsiveAttributeName])) {
-				breakpointVariables = setBreakpointResponsiveVariables(variables[responsiveAttributeName], breakpointName, breakpointIndex, numberOfBreakpoints);
-
-			// Object treatment goes depending on a value inserted(multiple choice, boolean or similar).
-			} else {
-
-				// Iterate options/multiple choices/boolean...
-				breakpointVariables = Object.entries(variables[responsiveAttributeName])
-				.reduce((acc, [attributeValue, attributeObject]) => {
-					return {
-						...acc,
-						[attributeValue]: setBreakpointResponsiveVariables(attributeObject, breakpointName, breakpointIndex, numberOfBreakpoints),
-					}
-				}, {});
+			// If responsive attribute doesn't exist in variables object, skip it.
+			if (!responsiveAttributeName || _.isEmpty(variables[responsiveAttributeName])) {
+				return responsiveAttributesVariables;
 			}
 
-			// Collect all the values from one responsive attribute to one object.
-			return {
-				...responsiveAttribute,
-				[breakpointVariableName]: breakpointVariables,
-			};
-		}, {});
+			// Used for determination of default breakpoint.
+			const numberOfBreakpoints = Object.entries(responsiveAttributeObject).length;
 
-		// Merge multiple responsive attributes to one object.
-		return {...responsiveAttributesVariables, ...responsiveAttributeVariables};
-	}, {});
+			// Iterate each responsive attribute object as breakpoint name is the key of the object,
+			// and value represents the name of the responsive variable.
+			const responsiveAttributeVariables = Object.entries(responsiveAttributeObject)
+				.reduce((responsiveAttribute, [breakpointName, breakpointVariableName], breakpointIndex) => {
+					let breakpointVariables = {};
+
+					if (Array.isArray(variables[responsiveAttributeName])) { // Array represents direct value(default or value).
+						breakpointVariables = setBreakpointResponsiveVariables(
+							variables[responsiveAttributeName],
+							breakpointName,
+							breakpointIndex,
+							numberOfBreakpoints
+						);
+						return {
+							...responsiveAttribute,
+							[breakpointVariableName]: breakpointVariables,
+						};
+					}
+
+					// Object treatment goes depending on a value inserted(multiple choice, boolean or similar).
+					// Iterate options/multiple choices/boolean...
+					breakpointVariables = Object.entries(variables[responsiveAttributeName])
+						.reduce((acc, [attributeValue, attributeObject]) => {
+							return {
+								...acc,
+								[attributeValue]: setBreakpointResponsiveVariables(attributeObject, breakpointName, breakpointIndex, numberOfBreakpoints),
+							}
+						}, {});
+
+					// Collect all the values from one responsive attribute to one object.
+					return {
+						...responsiveAttribute,
+						[breakpointVariableName]: breakpointVariables,
+					};
+				}, {});
+
+			// Merge multiple responsive attributes to one object.
+			return {...responsiveAttributesVariables, ...responsiveAttributeVariables};
+		}, {});
 }
 
 /**
@@ -166,21 +175,14 @@ const setVariablesToBreakpoints = (attributes, variables, data) => {
 		const attributeValue = attributes[variableName];
 
 		// Set internal breakpoints variable.
-		let internalBreakpoints = [];
-
-		// If type default or value.
-		if (!Array.isArray(variableValue)) {
-			internalBreakpoints = variableValue[attributeValue] ?? [];
-		} else {
-			internalBreakpoints = variableValue;
-		}
+		const internalBreakpoints = Array.isArray(variableValue) ? variableValue : (variableValue[attributeValue] ?? []);
 
 		// Iterate variable array to check breakpoints.
 		internalBreakpoints.forEach((breakpointItem) => {
 
 			// Define variables from breakpointItem.
 			const {
-				breakpoint = 'default', // If breakpoint is not set use default name
+				breakpoint = 'default', // If breakpoint is not set use default name.
 				inverse = false, // If inverse is not set use mobile first.
 				variable = [],
 			} = breakpointItem;


### PR DESCRIPTION
What this functionality brings is no need to rewrite the same values for each breakpoint in attributes, but to collect them as one in `variables` and reference all the breakpoints in `responsiveAttributes`. This brings us fewer points of a potential mistake(no need to enter the same code for each breakpoint), shortens the coding time(copying and correcting breakpoint name), shortens the code(images ⬇️ , wrapper 957 -> 491 LOC), and makes it altogether more simple to develop.

Specificity from the least specified to the most specified:
variables found in responsiveAttributes
variables
variablesEditor found in responsiveAttributes
variablesEditor

You can specify for example: `wrapperWidth` in `responsiveAttributes` and in `variables` but if you need something special or you need to override the default values(for something that is valid for all the other breakpoints), you can make a specific request as `wrapperWidthDesktop` and write separate definitions.
Values from `wrapperWidth` will still be defined but you can override them(images ⬇️ ).

Note:
Functionality should be ok, and backward compatibility should be completely ok.
The only concern is docs. If it is not clear please suggest for better or at least say what is not as clear as it should be.

Results screenshots:
![after](https://user-images.githubusercontent.com/46056662/120973995-e9a2f400-c76f-11eb-9467-cedff8564d1c.png)
![before](https://user-images.githubusercontent.com/46056662/120974007-ec9de480-c76f-11eb-9b12-a3ba152e81e9.png)
<img width="588" alt="for a specific breakpoint" src="https://user-images.githubusercontent.com/46056662/120974013-ed367b00-c76f-11eb-9078-4f2bc2f40e7c.png">
<img width="358" alt="after responsive attr" src="https://user-images.githubusercontent.com/46056662/120974922-fa079e80-c770-11eb-8b4f-759618225144.png">
<img width="338" alt="before responsive attr" src="https://user-images.githubusercontent.com/46056662/120974931-fbd16200-c770-11eb-88e8-d2e84ae313bf.png">