### PR TITLE
Props helper attribute renaming fix

### DIFF
--- a/scripts/editor/props.js
+++ b/scripts/editor/props.js
@@ -62,7 +62,7 @@ export const props = (attributes, realName, newName = '', isBlock = false, names
 
 			// Change the name of the key if they are different.
 			if (realName !== newNameInternal) {
-				newKey = realName + key.slice(newNameInternal.length);
+				newKey = key.replace(newNameInternal, realName);
 			}
 
 			// Populate output with new values.


### PR DESCRIPTION
The `props` helper was manifesting some weird behaviour with renaming some attribute names in nested components (for example (component1 -> component2 -> component3), so I switched it to use the safer `.replace()` method, which prevents slicing and dicing component names.