### PR TITLE
Setup tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
               run: npm install
 
             - name: Run unit tests
-              run: npm run testUnit
+              run: npm run test:unit

--- a/__mocks__/@eightshift/frontend-libs/mocks/wrapper.js
+++ b/__mocks__/@eightshift/frontend-libs/mocks/wrapper.js
@@ -1,0 +1,5 @@
+export const Wrapper = (props) => {
+	return (
+		<div>{props.children}</div>
+	);
+}

--- a/__mocks__/@eightshift/frontend-libs/scripts/editor.js
+++ b/__mocks__/@eightshift/frontend-libs/scripts/editor.js
@@ -1,0 +1,2 @@
+import editor from '../../../../scripts/editor';
+export default editor;

--- a/__mocks__/@eightshift/frontend-libs/scripts/helpers.js
+++ b/__mocks__/@eightshift/frontend-libs/scripts/helpers.js
@@ -1,0 +1,2 @@
+import helpers from '../../../../scripts/helpers';
+export default helpers;

--- a/__mocks__/@wordpress/block-editor.js
+++ b/__mocks__/@wordpress/block-editor.js
@@ -1,0 +1,18 @@
+/**
+ * Mock of the @wordpress/block-editor package. You can add mocks for new stores to the `mockSelectors` method.
+ */
+
+/**
+ * Mock of the import { InnerBlocks } from '@wordpress/block-editor';
+ */
+export const InnerBlocks = () => {
+	return (
+		<div>InnerBlocks</div>
+	);
+}
+
+export const InspectorControls = (props) => {
+	return (
+		<div>{props.children}</div>
+	);
+}

--- a/__mocks__/@wordpress/blocks.js
+++ b/__mocks__/@wordpress/blocks.js
@@ -1,0 +1,23 @@
+/**
+ * Mock of the @wordpress/blocks package. You can add mocks for new stores to the `mockSelectors` method.
+ */
+
+/**
+ * Mock of the import { registerBlockType } from '@wordpress/blocks';
+ */
+export const registerBlockType = (blockName, options = {}) => {
+	return {
+		blockName,
+		options
+	};
+}
+
+/**
+ * Mock of the import { registerBlockVariation } from '@wordpress/blocks';
+ */
+export const registerBlockVariation = (blockName, options = {}) => {
+	return {
+		blockName,
+		options
+	};
+}

--- a/__mocks__/@wordpress/element.js
+++ b/__mocks__/@wordpress/element.js
@@ -1,0 +1,16 @@
+/**
+ * Mock of the @wordpress/element package. You can add mocks for new stores to the `mockSelectors` method.
+ */
+
+/**
+ * Mock of the import { createElement } from '@wordpress/element';
+ */
+export const createElement = () => {
+	return 'createElement';
+}
+
+export const Fragment = (props) => {
+	return (
+		<div>{props.children}</div>
+	);
+}

--- a/__mocks__/react-html-parser.js
+++ b/__mocks__/react-html-parser.js
@@ -1,0 +1,7 @@
+const reactHtmlParser = () => {
+	return [
+		'<svg></svg>'
+	];
+}
+
+export default reactHtmlParser;

--- a/babel/babel.config.js
+++ b/babel/babel.config.js
@@ -24,15 +24,6 @@ module.exports = {
 		],
 	],
 	env: {
-		test: {
-			presets: [
-				[
-					'@babel/preset-env', {modules: 'commonjs'}
-				]
-			],
-			plugins: [
-				'@babel/plugin-transform-modules-commonjs'
-			]
-		}
+		test: {}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 		"docsBuild": "rm -rf docs && npm run sassdocBuild && npm run storybookBuild",
 		"docsDeploy": "npm run docsBuild && gh-pages -d docs",
 		"test": "NODE_ENV=test jest --maxWorkers=2",
-		"testUnit": "NODE_ENV=test jest --testPathPattern=tests/unit",
-		"testIntegration": "jest --testPathPattern=tests/integration"
+		"test:unit": "NODE_ENV=test jest --testPathPattern=tests/unit",
+		"test:integration": "jest --testPathPattern=tests/integration"
 	},
 	"homepage": "https://github.com/infinum/eightshift-frontend-libs#readme",
 	"license": "MIT",
@@ -92,12 +92,16 @@
 	},
 	"devDependencies": {
 		"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+		"@babel/preset-env": "^7.14.7",
+		"@babel/preset-react": "^7.14.5",
 		"@eightshift/storybook": "^5.6",
-		"@jest/globals": "^26.6.2",
+		"@jest/globals": "^27.0.6",
+		"babel-jest": "^27.0.6",
 		"chalk": "^4.1.0",
 		"del": "^6.0.0",
 		"gh-pages": "^3.1.0",
-		"jest": "^26.6.3",
+		"jest": "^27.0.6",
+		"react-test-renderer": "^17.0.2",
 		"replace-in-file": "^6.2.0",
 		"sassdoc": "^2.7.3"
 	},

--- a/package.json
+++ b/package.json
@@ -100,13 +100,15 @@
 		"chalk": "^4.1.0",
 		"del": "^6.0.0",
 		"gh-pages": "^3.1.0",
-		"jest": "^27.0.6",
+		"jest": "^26.6.3",
+		"jest-expect-message": "^1.0.2",
 		"react-test-renderer": "^17.0.2",
 		"replace-in-file": "^6.2.0",
 		"sassdoc": "^2.7.3"
 	},
 	"sideEffects": false,
 	"jest": {
+		"setupFilesAfterEnv": ["jest-expect-message"],
 		"verbose": true,
 		"transform": {
 			"\\.js$": [

--- a/scripts/editor/icons/icons.js
+++ b/scripts/editor/icons/icons.js
@@ -1,4 +1,4 @@
-// import React from 'react';
+import React from 'react';
 
 /**
  * UI icons.

--- a/scripts/editor/icons/icons.js
+++ b/scripts/editor/icons/icons.js
@@ -1,4 +1,4 @@
-import React from 'react';
+// import React from 'react';
 
 /**
  * UI icons.

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -538,7 +538,7 @@ export const registerBlocks = (
 	buildWindowObject(globalManifest, componentsManifest, blocksManifests, wrapperManifest);
 
 	// Iterate blocks to register.
-	const registeredBlocks = blocksManifests.map((blockManifest) => {
+	blocksManifests.map((blockManifest) => {
 
 		// Get Block edit component from block name and blocksEditComponentPath.
 		const blockComponent = getBlockEditComponent(blockManifest.blockName, blocksEditComponentPath, 'block');
@@ -572,13 +572,7 @@ export const registerBlocks = (
 		);
 
 		// Native WP method for block registration.
-		if (NODE_ENV && NODE_ENV === 'test') {
-			return {
-				name: blockDetails.blockName
-			};
-		} else {
-			registerBlockType(blockDetails.blockName, blockDetails.options);
-		}
+		registerBlockType(blockDetails.blockName, blockDetails.options);
 
 		return null;
 	});
@@ -591,8 +585,6 @@ export const registerBlocks = (
 
 	document.documentElement.style.setProperty('--eightshift-block-icon-foreground', foregroundGlobal);
 	document.documentElement.style.setProperty('--eightshift-block-icon-background', backgroundGlobal);
-
-	return registeredBlocks;
 };
 
 /**

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -1,3 +1,4 @@
+/* global NODE_ENV */
 import React from 'react';
 import _ from 'lodash';
 import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
@@ -537,7 +538,7 @@ export const registerBlocks = (
 	buildWindowObject(globalManifest, componentsManifest, blocksManifests, wrapperManifest);
 
 	// Iterate blocks to register.
-	blocksManifests.map((blockManifest) => {
+	const registeredBlocks = blocksManifests.map((blockManifest) => {
 
 		// Get Block edit component from block name and blocksEditComponentPath.
 		const blockComponent = getBlockEditComponent(blockManifest.blockName, blocksEditComponentPath, 'block');
@@ -571,7 +572,13 @@ export const registerBlocks = (
 		);
 
 		// Native WP method for block registration.
-		registerBlockType(blockDetails.blockName, blockDetails.options);
+		if (NODE_ENV && NODE_ENV === 'test') {
+			return {
+				name: blockDetails.blockName
+			};
+		} else {
+			registerBlockType(blockDetails.blockName, blockDetails.options);
+		}
 
 		return null;
 	});
@@ -584,6 +591,8 @@ export const registerBlocks = (
 
 	document.documentElement.style.setProperty('--eightshift-block-icon-foreground', foregroundGlobal);
 	document.documentElement.style.setProperty('--eightshift-block-icon-background', backgroundGlobal);
+
+	return registeredBlocks;
 };
 
 /**

--- a/tests/data/block-attributes.js
+++ b/tests/data/block-attributes.js
@@ -1,0 +1,15 @@
+/**
+ * Define all expected block attributes (after taking into consideration their dependencies)
+ * you wish to test here.
+ */
+export const blockAttributes = {
+	carousel: {
+		expected:[
+			'wrapperUse',
+			'carouselAllowedBlocks'
+		],
+		notExpected: [
+			'headingContent',
+		]
+	},
+};

--- a/tests/data/block-attributes.js
+++ b/tests/data/block-attributes.js
@@ -12,4 +12,12 @@ export const blockAttributes = {
 			'headingContent',
 		]
 	},
+	'mock-blockquote': {
+		expected:[
+			'headingContent',
+		],
+		notExpected: [
+			'headingaaaContent',
+		]
+	},
 };

--- a/tests/data/props-output.js
+++ b/tests/data/props-output.js
@@ -3,6 +3,19 @@
  * dependencies.
  */
 export const propsOutput = {
+	accordion: {
+		components: {
+			accordion: {
+				expected: [
+					'accordionContent',
+					'accordionTitle',
+				],
+				notExpected: [
+					'accordionAccordionContent',
+				]
+			}
+		}
+	},
 	'mock-blockquote': {
 		components: {
 			blockquote: {
@@ -74,7 +87,6 @@ export const propsOutput = {
 				notExpected: [
 					'blockquoteCardImageUrl',
 				],
-				prefix: 'card',
 				components: {
 					image: {
 						expected: [

--- a/tests/data/props-output.js
+++ b/tests/data/props-output.js
@@ -67,12 +67,9 @@ export const propsOutput = {
 			card: {
 				expected: [
 					'cardAlign',
-					// 'cardHeadingContent',
-					// 'cardImageUrl',
-					// 'cardButtonContent',
-					'headingContent',
-					'imageUrl',
-					'buttonContent',
+					'cardHeadingContent',
+					'cardImageUrl',
+					'cardButtonContent',
 				],
 				notExpected: [
 					'blockquoteCardImageUrl',

--- a/tests/data/props-output.js
+++ b/tests/data/props-output.js
@@ -1,0 +1,146 @@
+/**
+ * Define what props should or should not return on each lvl of a dependency tree, using the newName to identify 
+ * dependencies.
+ */
+export const propsOutput = {
+	'mock-blockquote': {
+		components: {
+			blockquote: {
+				expected: [
+					'blockquoteBlockquoteImageUrl',
+					'blockquoteBlockquoteHeadingContent',
+				],
+				notExpected: [
+					'blockquoteCardImageUrl',
+				],
+				prefix: 'blockquote',
+				components: {
+					blockquote: {
+						expected: [
+							'blockquoteBlockquoteImageUrl',
+							'blockquoteBlockquoteHeadingContent',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+						],
+						prefix: 'blockquoteBlockquote',
+						components: {
+							image: {
+								expected: [
+									'blockquoteBlockquoteImageUrl',
+								],
+								notExpected: [
+									'blockquoteBlockquoteHeadingContent',
+									'blockquoteBlockquoteIntroContent',
+								],
+								prefix: 'blockquoteBlockquoteImage',
+							},
+							heading: {
+								expected: [
+									'blockquoteBlockquoteHeadingContent',
+								],
+								notExpected: [
+									'blockquoteBlockquoteImageUrl',
+									'blockquoteBlockquoteIntroContent',
+								],
+								prefix: 'blockquoteBlockquoteHeading',
+							},
+							intro: {
+								expected: [
+									'blockquoteBlockquoteIntroTypographyContent',
+								],
+								notExpected: [
+									'blockquoteBlockquoteImageUrl',
+									'blockquoteBlockquoteIntroContent',
+									'blockquoteBlockquoteHeadingContent',
+								],
+								prefix: 'blockquoteBlockquoteIntro',
+							},
+						}
+					}
+				}
+			}
+		}
+	},
+	card: {
+		components: {
+			card: {
+				expected: [
+					'cardAlign',
+					// 'cardHeadingContent',
+					// 'cardImageUrl',
+					// 'cardButtonContent',
+					'headingContent',
+					'imageUrl',
+					'buttonContent',
+				],
+				notExpected: [
+					'blockquoteCardImageUrl',
+				],
+				prefix: 'card',
+				components: {
+					image: {
+						expected: [
+							'cardImageUrl',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+							'cardAlign',
+							'cardHeadingContent',
+							'cardButtonContent',
+						],
+						prefix: 'cardImage',
+					},
+					intro: {
+						expected: [
+							'cardIntroContent',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+							'cardAlign',
+							'cardHeadingContent',
+							'cardButtonContent',
+						],
+						prefix: 'cardIntro',
+					},
+					heading: {
+						expected: [
+							'cardHeadingContent',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+							'cardAlign',
+							'cardIntroContent',
+							'cardButtonContent',
+						],
+						prefix: 'cardHeading',
+					},
+					paragraph: {
+						expected: [
+							'cardParagraphContent',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+							'cardAlign',
+							'cardIntroContent',
+							'cardButtonContent',
+						],
+						prefix: 'cardParagraph',
+					},
+					button: {
+						expected: [
+							'cardButtonContent',
+						],
+						notExpected: [
+							'blockquoteCardImageUrl',
+							'cardAlign',
+							'cardIntroContent',
+							'cardParagraphContent',
+						],
+						prefix: 'cardButton',
+					}
+				}
+			}
+		}
+	}
+};

--- a/tests/data/src/Blocks/components/mock-blockquote/manifest.json
+++ b/tests/data/src/Blocks/components/mock-blockquote/manifest.json
@@ -1,0 +1,8 @@
+{
+	"componentName": "mock-blockquote",
+	"title": "mock blockquote",
+	"componentClass": "blockquote",
+	"components": {
+		"blockquote": "card"
+	}
+}

--- a/tests/data/src/Blocks/components/mock-blockquote/manifest.json
+++ b/tests/data/src/Blocks/components/mock-blockquote/manifest.json
@@ -3,6 +3,6 @@
 	"title": "mock blockquote",
 	"componentClass": "blockquote",
 	"components": {
-		"blockquote": "card"
+		"blockquote": "mock-card"
 	}
 }

--- a/tests/data/src/Blocks/components/mock-card/manifest.json
+++ b/tests/data/src/Blocks/components/mock-card/manifest.json
@@ -1,0 +1,90 @@
+{
+	"componentName": "mock-card",
+	"title": "Mock Card",
+	"componentClass": "mock-card",
+	"example": {
+		"attributes": {
+			"introContent": "This is intro",
+			"introSize": "small",
+			"introColor": "light"
+		}
+	},
+	"attributes": {
+		"cardContentAlign": {
+			"type": "string",
+			"default": "left"
+		},
+		"cardMediaAlign": {
+			"type": "string",
+			"default": "left"
+		},
+		"cardMediaInset": {
+			"type": "integer",
+			"default": 0
+		},
+		"cardContentInset": {
+			"type": "integer",
+			"default": 0
+		},
+		"cardSyncInsets": {
+			"type": "boolean",
+			"default": true
+		},
+		"cardIntroBelow": {
+			"type": "boolean",
+			"default": false
+		},
+		"cardShowBorder": {
+			"type": "boolean",
+			"default": false
+		},
+		"introUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"buttonUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"chevronUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"imageUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"iconUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"iconSize": {
+			"type": "string",
+			"default": "6"
+		},
+		"introUppercase": {
+			"type": "boolean",
+			"default": true
+		},
+		"headingSize": {
+			"type": "string",
+			"default": "36-bold"
+		},
+		"introSize": {
+			"type": "string",
+			"default": "14-regular"
+		},
+		"paragraphSize": {
+			"type": "string",
+			"default": "16-regular"
+		}
+	},
+	"components": {
+		"image": "image",
+		"heading": "heading",
+		"intro": "mock-paragraph",
+		"paragraph": "mock-paragraph",
+		"icon": "icon",
+		"button": "button"
+	}
+}

--- a/tests/data/src/Blocks/components/mock-paragraph/manifest.json
+++ b/tests/data/src/Blocks/components/mock-paragraph/manifest.json
@@ -1,0 +1,19 @@
+{
+	"componentName": "mock-paragraph",
+	"title": "Mock Paragraph",
+	"componentClass": "mock-paragraph",
+	"example": {
+		"attributes": {
+			"paragraphContent": "This is paragraph",
+			"paragraphLevel": 2,
+			"paragraphTag": "p",
+			"paragraphSize": "16-regular",
+			"paragraphColor": "black",
+			"paragraphUppercase": false,
+			"paragraphUse": true
+		}
+	},
+	"components": {
+		"mockParagraph": "mock-typography"
+	}
+}

--- a/tests/data/src/Blocks/components/mock-typography/manifest.json
+++ b/tests/data/src/Blocks/components/mock-typography/manifest.json
@@ -1,0 +1,49 @@
+{
+	"componentName": "mock-typography",
+	"title": "Mock Typography",
+	"componentClass": "mock-typography",
+	"example": {
+		"attributes": {
+			"typographyContent": "This is typography",
+			"typographyLevel": 2,
+			"typographyTag": "p",
+			"typographySize": "16-regular",
+			"typographyColor": "black",
+			"typographyUppercase": false,
+			"typographyUse": true
+		}
+	},
+	"attributes": {
+		"typographyContent": {
+			"type": "string",
+			"seo": true
+		},
+		"typographyTag": {
+			"type": "string",
+			"default": "p"
+		},
+		"typographyLevel": {
+			"type": "integer",
+			"default": 2
+		},
+		"typographySize": {
+			"type": "string",
+			"default": "16-regular"
+		},
+		"typographyColor": {
+			"type": "string"
+		},
+		"typographyUppercase": {
+			"type": "boolean",
+			"default": false
+		},
+		"typographyUse": {
+			"type": "boolean",
+			"default": true
+		},
+		"typographyHighlightColor": {
+			"type": "string",
+			"default": ""
+		}
+	}
+}

--- a/tests/data/src/Blocks/custom/mock-blockquote/manifest.json
+++ b/tests/data/src/Blocks/custom/mock-blockquote/manifest.json
@@ -1,0 +1,16 @@
+{
+	"blockName": "mock-blockquote",
+	"title": "Mock blockquote",
+	"description" : "Blockquote block with custom settings.",
+	"category": "eightshift",
+	"icon": {
+		"src": "es-card-review"
+	},
+	"keywords": [
+		"blockquote",
+		"quote"
+	],
+	"components": {
+		"blockquote": "mock-blockquote"
+	}
+}

--- a/tests/helpers/blocks.js
+++ b/tests/helpers/blocks.js
@@ -81,18 +81,20 @@ export const recursiveBuildProps = (attributes, componentManifests, realName, ne
 	let propsArray = [];
 	const isNameDifferent = realName !== newName;
 	const newComponentAttributes = props(attributes, realName, isNameDifferent ? newName : '', isBlock);
-	propsArray = [...propsArray, {
+	const componentOutput = {
 		realName,
 		newName,
 		attributes: newComponentAttributes,
-	}];
-
+		subComponents: [],
+	};
+	
 	// Check if this component has any sub-components and recursively call this function.
-	const components = getComponentDependencies(componentManifests, realName);
+	const components = getComponentDependencies(componentManifests, realName, newName);
 	for (const subNewName of Object.keys(components)) {
 		const subRealName = components[subNewName];
-		propsArray = [...propsArray, ...recursiveBuildProps(newComponentAttributes, componentManifests, subRealName, subNewName)];
+		componentOutput.subComponents = [...componentOutput.subComponents, ...recursiveBuildProps(newComponentAttributes, componentManifests, subRealName, subNewName)]
 	}
-
+	
+	propsArray = [...propsArray, componentOutput];
 	return propsArray;
 }

--- a/tests/helpers/blocks.js
+++ b/tests/helpers/blocks.js
@@ -1,0 +1,52 @@
+import Path from 'path';
+import { readdirSync, readFileSync } from "fs";
+import { props } from '../../scripts/editor';
+
+const pathToBlocksFolder = Path.resolve(__dirname, '..', '..', 'blocks', 'init', 'src', 'Blocks');
+const pathToComponents = Path.resolve(pathToBlocksFolder, 'components');
+const pathToBlocks = Path.resolve(pathToBlocksFolder, 'custom');
+
+const pathToMockBlocksFolder = Path.resolve(__dirname, '..', 'data', 'src', 'Blocks');
+const pathToMockComponents = Path.resolve(pathToMockBlocksFolder, 'components');
+const pathToMockBlocks = Path.resolve(pathToMockBlocksFolder, 'custom');
+
+/**
+ * Returns all manifests from directories inside `dir`.
+ *
+ * @param {string} dir Full path to dir in which we're looking for other 
+ * 										 dirs (components / blocks) which have manifest.json inside.
+ * 										 Example: 'blocks/init/src/Blocks/components'
+ * @returns {array<object>} Array of manifest.json contents
+ */
+const getAllManifestsFromDir = (dir) => {
+	const manifestDirs = readdirSync(dir);
+	return manifestDirs.map((manifestDir) => {
+		const manifestPath = Path.resolve(dir, manifestDir, 'manifest.json');
+		const manifest = JSON.parse(readFileSync(manifestPath));
+		return manifest;
+	});
+}
+
+/**
+ * Get all components, both the mock ones specifically for tests and the actual libs blocks.
+ * 
+ * @return {array}
+ */
+export const getAllComponentManifests = () => {
+	const componentManifests = getAllManifestsFromDir(pathToComponents);
+	const mockComponentManifests = getAllManifestsFromDir(pathToMockComponents);
+	return [...componentManifests, ...mockComponentManifests];
+}
+
+/**
+ * Get all components, both the mock ones specifically for tests and the actual libs blocks.
+ *
+ * @return {array}
+ */
+export const getAllBlockManifests = () => {
+	const blockManifests = getAllManifestsFromDir(pathToBlocks);
+	const mockBlockManifests = getAllManifestsFromDir(pathToMockBlocks);
+	return [...blockManifests, ...mockBlockManifests];
+}
+
+/**

--- a/tests/helpers/blocks.js
+++ b/tests/helpers/blocks.js
@@ -22,8 +22,7 @@ const getAllManifestsFromDir = (dir) => {
 	const manifestDirs = readdirSync(dir);
 	return manifestDirs.map((manifestDir) => {
 		const manifestPath = Path.resolve(dir, manifestDir, 'manifest.json');
-		const manifest = JSON.parse(readFileSync(manifestPath));
-		return manifest;
+		return JSON.parse(readFileSync(manifestPath));
 	});
 }
 
@@ -105,13 +104,6 @@ export const recursiveBuildProps = (attributes, componentManifests, realName, ne
 	const isNameDifferent = realName !== newName;
 	const newComponentAttributes = props(attributes, isNameDifferent ? newName : realName);
 
-	// console.log(newComponentAttributes);
-	// console.log('newComponentAttributes', {
-	// 	newName,
-	// 	realName,
-	// 	isNameDifferent
-	// });
-
 	const componentOutput = {
 		realName,
 		newName,
@@ -129,6 +121,5 @@ export const recursiveBuildProps = (attributes, componentManifests, realName, ne
 		];
 	}
 
-	propsArray = [...propsArray, componentOutput];
-	return propsArray;
+	return [...propsArray, componentOutput];
 }

--- a/tests/helpers/blocks.js
+++ b/tests/helpers/blocks.js
@@ -14,8 +14,8 @@ const pathToMockBlocks = Path.resolve(pathToMockBlocksFolder, 'custom');
  * Returns all manifests from directories inside `dir`.
  *
  * @param {string} dir Full path to dir in which we're looking for other 
- * 										 dirs (components / blocks) which have manifest.json inside.
- * 										 Example: 'blocks/init/src/Blocks/components'
+ *                     dirs (components / blocks) which have manifest.json inside.
+ *                     Example: 'blocks/init/src/Blocks/components'
  * @returns {array<object>} Array of manifest.json contents
  */
 const getAllManifestsFromDir = (dir) => {
@@ -62,7 +62,7 @@ export const getAllBlockManifests = () => {
 export const getComponentDependencies = (componentManifests, componentName) => {
 	let components = {};
 
-	for(const componentManifest of componentManifests) {
+	for (const componentManifest of componentManifests) {
 		if (componentManifest.componentName === componentName && componentManifest.components) {
 			components = componentManifest.components;
 			break;
@@ -87,14 +87,17 @@ export const recursiveBuildProps = (attributes, componentManifests, realName, ne
 		attributes: newComponentAttributes,
 		subComponents: [],
 	};
-	
+
 	// Check if this component has any sub-components and recursively call this function.
 	const components = getComponentDependencies(componentManifests, realName, newName);
 	for (const subNewName of Object.keys(components)) {
 		const subRealName = components[subNewName];
-		componentOutput.subComponents = [...componentOutput.subComponents, ...recursiveBuildProps(newComponentAttributes, componentManifests, subRealName, subNewName)]
+		componentOutput.subComponents = [
+			...componentOutput.subComponents,
+			...recursiveBuildProps(newComponentAttributes, componentManifests, subRealName, subNewName)
+		];
 	}
-	
+
 	propsArray = [...propsArray, componentOutput];
 	return propsArray;
 }

--- a/tests/helpers/blocks.js
+++ b/tests/helpers/blocks.js
@@ -73,14 +73,45 @@ export const getComponentDependencies = (componentManifests, componentName) => {
 }
 
 /**
+ * Returns an object composed of all component dependencies (if they exist) if the following format:
+ * {
+ * 	 newName: realName
+ * }
+ *
+ * @param {array<object>} blockManifests Array of all block manifests
+ * @param {string} blockName Block name for which we want to get dependency components
+ * @return {object}
+ */
+export const getBlockDependencies = (blockManifests, blockName) => {
+	let components = {};
+
+	for (const blockManifest of blockManifests) {
+		if (blockManifest.blockName === blockName && blockManifest.components) {
+			components = blockManifest.components;
+			break;
+		}
+	}
+
+	return components;
+}
+
+/**
  * Recursively builds props for a block and all it's sub dependencies.
  */
-export const recursiveBuildProps = (attributes, componentManifests, realName, newName, isBlock = false) => {
+export const recursiveBuildProps = (attributes, componentManifests, realName, newName) => {
 
 	// Output props for all components.
 	let propsArray = [];
 	const isNameDifferent = realName !== newName;
-	const newComponentAttributes = props(attributes, realName, isNameDifferent ? newName : '', isBlock);
+	const newComponentAttributes = props(attributes, isNameDifferent ? newName : realName);
+
+	// console.log(newComponentAttributes);
+	// console.log('newComponentAttributes', {
+	// 	newName,
+	// 	realName,
+	// 	isNameDifferent
+	// });
+
 	const componentOutput = {
 		realName,
 		newName,

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -53,6 +53,7 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 			builtProps.attributes,
 			`Missing "prefix" key in built props for ${debugName(builtProps)}`
 		).toHaveProperty('prefix');
+
 		expect(
 			builtProps.attributes.prefix,
 			`Prefix key not correct when sending props to ${debugName(builtProps)}`
@@ -68,6 +69,7 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 				builtProps,
 				`Missing "subComponents" key in built props for ${debugName(builtProps)}. Expecting one because this has subComponents defined in props-output.js`
 			).toHaveProperty('subComponents');
+
 			expect(
 				builtProps.subComponents,
 				`"subComponents" key in built props empty for ${debugName(builtProps)}.`
@@ -154,8 +156,6 @@ it('tests that props helper builds the attributes / prefix correctly for all blo
 		};
 
 		const components = getBlockDependencies(blockManifests, blockManifest.blockName);
-		console.log('Running for block: ', blockManifest.blockName);
-		console.log(components);
 		for (const newName of Object.keys(components)) {
 			console.log('running for ', newName);
 			const realName = components[newName];

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Path from 'path';
+import { readdirSync, readFileSync } from "fs";
+import { buildWindowObject, getAttributes } from '../../../scripts/editor/register-blocks';
+import wrapperManifest from '../../../blocks/init/src/Blocks/wrapper/manifest.json';
+import globalManifest from '../../../blocks/init/src/Blocks/manifest.json';
+import { blockAttributes } from '../../data/block-attributes';
+import { expect } from '@jest/globals';
+
+const pathToBlocksFolder = Path.resolve(__dirname, '..', '..', '..', 'blocks', 'init', 'src', 'Blocks');
+const pathToComponents = Path.resolve(pathToBlocksFolder, 'components');
+const pathToBlocks = Path.resolve(pathToBlocksFolder, 'custom');
+
+/**
+ * Unit tests for get-option-colors.js helper
+ *
+ * @group unit
+ */
+it('tests block registration properly inherits all component attributes', () => {
+
+	const blockDirs = readdirSync(pathToBlocks);
+	const blockManifests = blockDirs.map((blockDir) => {
+		const manifestPath = Path.resolve(pathToBlocks, blockDir, 'manifest.json');
+		const manifest = JSON.parse(readFileSync(manifestPath));
+		return manifest;
+	});
+
+	const componentDirs = readdirSync(pathToComponents);
+	const componentManifests = componentDirs.map((componentDir) => {
+		const manifestPath = Path.resolve(pathToComponents, componentDir, 'manifest.json');
+		const manifest = JSON.parse(readFileSync(manifestPath));
+		return manifest;
+	});
+
+
+	// Build an array of expected attributes in each block.
+	buildWindowObject(globalManifest, componentManifests, blockManifests, wrapperManifest);
+
+	let blocks = [];
+	for (const blockManifest of blockManifests) {
+		const blockName = blockManifest.blockName;
+		const attributeNames = Object.keys(getAttributes(globalManifest, wrapperManifest, componentManifests, blockManifest));
+
+		// Only test blocks which expected / not expected attributes defined.
+		if (!blockAttributes[blockName]) {
+			continue;
+		}
+
+		// Make sure the block contains all expected attributes
+		if (blockAttributes[blockName].expected) {
+			expect(attributeNames).toEqual(expect.arrayContaining(blockAttributes[blockName].expected));
+		}
+
+		// Make sure the block does not contain nonExpected attributes
+		if (blockAttributes[blockName].notExpected) {
+			for(const notExpected of blockAttributes[blockName].notExpected) {
+				expect(attributeNames).not.toEqual(expect.arrayContaining([notExpected]));
+			}
+		}
+	}
+});

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -167,9 +167,7 @@ it('tests that props helper builds the attributes / prefix correctly for all blo
 
 			const blockExpectedProps = propsOutput[blockProps.realName];
 
-			expect(blockExpectedProps).toHaveProperty('components') // true
-
-			for (let subComponentKey of Object.keys(blockExpectedProps.components)) {
+			for (let subComponentKey of Object.keys(blockExpectedProps.components || [])) {
 				recursiveAssertProps(blockExpectedProps.components[subComponentKey], blockProps);
 			}
 		}

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -1,13 +1,91 @@
 /**
  * @jest-environment jsdom
  */
-
+import 'jest-expect-message'
 import { buildWindowObject, getAttributes } from '../../../scripts/editor/register-blocks';
 import wrapperManifest from '../../../blocks/init/src/Blocks/wrapper/manifest.json';
 import globalManifest from '../../../blocks/init/src/Blocks/manifest.json';
 import { blockAttributes } from '../../data/block-attributes';
 import { expect } from '@jest/globals';
 import { getAllComponentManifests, getAllBlockManifests, getComponentDependencies, recursiveBuildProps } from '../../helpers/blocks';
+import { propsOutput } from '../../data/props-output';
+
+/**
+ * Returns the name of the component from builtProps.
+ *
+ * @param {object} builtProps Built props for a component
+ * @returns {string}
+ */
+const debugName = (builtProps) => {
+	return `"${builtProps.realName}" (newName: "${builtProps.newName || builtProps.realName}") component`;
+}
+
+/**
+ * Asserts that built props match the expected output.
+ *
+ * @param {object} expectedProps propsOutput object for specific component
+ * @param {object} builtProps Props built for this object.
+ */
+const recursiveAssertProps = (expectedProps, builtProps) => {
+
+	// Some sanity checkcs
+	expect(
+		builtProps,
+		`Missing attributes key in built props for: ${debugName(builtProps)}`
+	).toHaveProperty('attributes');
+
+	// Check expected
+	for (const expected of expectedProps.expected) {
+		expect(
+			builtProps.attributes,
+			`Missing expected property in built props for: ${debugName(builtProps)}`
+		).toHaveProperty(expected);
+	}
+
+	// Check not expected
+	for (const notExpected of expectedProps.notExpected) {
+		expect(builtProps.attributes).not.toHaveProperty(notExpected);
+	}
+
+	// Check prefix
+	expect(
+		builtProps.attributes,
+		`Missing "prefix" key in built props for ${debugName(builtProps)}`
+	).toHaveProperty('prefix');
+	expect(
+		builtProps.attributes.prefix,
+		`Prefix key not correct when sending props to ${debugName(builtProps)}`
+	).toEqual(expectedProps.prefix);
+
+	// Repeat if expected has subComponents
+	if (expectedProps.components && Object.keys(expectedProps.components).length > 0) {
+		for (const componentKey of Object.keys(expectedProps.components)) {
+
+			// Expect built props has subComponents
+			expect(
+				buildProps,
+				`Missing "subComponents" key in built props for ${debugName(builtProps)}. Expecting one because this has subComponents defined in props-output.js`
+			).toHaveProperty('subComponents');
+			expect(
+				buildProps.subComponents,
+				`"subComponents" key in built props empty for ${debugName(builtProps)}.`
+			).not.toEqual([]);
+
+			// Find the correct subComponent
+			const subComponent = builtProps.subComponents.filter((subComponent) => subComponent.newName === componentKey);
+
+			// Expect to find exactly 1 sub component
+			expect(
+				subComponent,
+				`Expected subComponent not found in built props for ${debugName(builtProps)}.`
+			).toHaveLength(1);
+
+			// Repeat for all subComponents
+			recursiveAssertProps(expectedProps.components[componentKey], subComponent[0]);
+		}
+	}
+}
+
 
 /**
  * Unit tests for get-option-colors.js helper
@@ -34,19 +112,25 @@ it('tests block registration properly inherits all component attributes', () => 
 
 		// Make sure the block contains all expected attributes
 		if (blockAttributes[blockName].expected) {
-			expect(attributeNames).toEqual(expect.arrayContaining(blockAttributes[blockName].expected));
+			expect(
+				attributeNames,
+				`Block ${blockName} does not contain all expected attributes`
+			).toEqual(expect.arrayContaining(blockAttributes[blockName].expected));
 		}
 
 		// Make sure the block does not contain nonExpected attributes
 		if (blockAttributes[blockName].notExpected) {
 			for (const notExpected of blockAttributes[blockName].notExpected) {
-				expect(attributeNames).not.toEqual(expect.arrayContaining([notExpected]));
+				expect(
+					attributeNames,
+					`Block ${blockName} contains some non-expected attributes`
+				).not.toEqual(expect.arrayContaining([notExpected]));
 			}
 		}
 	}
 });
 
-it('tests that props helper builds the prefix correctly', () => {
+it('tests that props helper builds the attributes / prefix correctly for all blocks', () => {
 	const componentManifests = getAllComponentManifests();
 	const blockManifests = getAllBlockManifests();
 
@@ -54,34 +138,40 @@ it('tests that props helper builds the prefix correctly', () => {
 	buildWindowObject(globalManifest, componentManifests, blockManifests, wrapperManifest);
 
 	// Test all block manifests.
-	// for (const blockManifest of blockManifests) {
-	// 	const blockName = blockManifest.blockName;
-	// 	const attributes = getAttributes(globalManifest, wrapperManifest, componentManifests, blockManifest);
-
-	// 	new componentAttributes = {...props(attributes, camelize(blockName), '', true)};
-	// }
-
-	// TEMP
-	let testManifest = {};
 	for (const blockManifest of blockManifests) {
-		const blockName = blockManifest.blockName;
+		const attributes = getAttributes(globalManifest, wrapperManifest, componentManifests, blockManifest);
 
-		if (blockName === 'mock-blockquote') {
-			testManifest = blockManifest;
-			break;
+		// Build props for the current component.
+		let props = [];
+		const blockOutput = {
+			attributes,
+			realName: blockManifest.blockName,
+			newName: '',
+			subComponents: []
+		};
+
+		const components = getComponentDependencies(componentManifests, blockManifest.blockName);
+		for (const newName of Object.keys(components)) {
+			const realName = components[newName];
+			blockOutput.subComponents = [...blockOutput.subComponents, ...recursiveBuildProps(attributes, componentManifests, realName, newName, true)];
+		}
+
+		props = [...props, blockOutput];
+
+		for (let blockProps of props) {
+
+			// Only run on on blocks we manually defined props output for.
+			if (!propsOutput[blockProps.realName]) {
+				continue
+			}
+
+			const blockExpectedProps = propsOutput[blockProps.realName];
+
+			expect(blockExpectedProps).toHaveProperty('components') // true
+
+			for (let subComponentKey of Object.keys(blockExpectedProps.components)) {
+				recursiveAssertProps(blockExpectedProps.components[subComponentKey], blockProps);
+			}
 		}
 	}
-
-	const attributes = getAttributes(globalManifest, wrapperManifest, componentManifests, testManifest);
-
-	// Build props for the current component.
-	// const props = recursiveBuildProps(attributes, componentManifests, testManifest.blockName);
-	let props = [];
-	const components = getComponentDependencies(componentManifests, testManifest.blockName);
-	for (const newName of Object.keys(components)) {
-		const realName = components[newName];
-		props = [...props, ...recursiveBuildProps(attributes, componentManifests, realName, newName, true)]
-	}
-
-	console.log(props);
 });

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -86,7 +86,6 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 	}
 }
 
-
 /**
  * Unit tests for get-option-colors.js helper
  *

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -2,17 +2,12 @@
  * @jest-environment jsdom
  */
 
-import Path from 'path';
-import { readdirSync, readFileSync } from "fs";
 import { buildWindowObject, getAttributes } from '../../../scripts/editor/register-blocks';
 import wrapperManifest from '../../../blocks/init/src/Blocks/wrapper/manifest.json';
 import globalManifest from '../../../blocks/init/src/Blocks/manifest.json';
 import { blockAttributes } from '../../data/block-attributes';
 import { expect } from '@jest/globals';
-
-const pathToBlocksFolder = Path.resolve(__dirname, '..', '..', '..', 'blocks', 'init', 'src', 'Blocks');
-const pathToComponents = Path.resolve(pathToBlocksFolder, 'components');
-const pathToBlocks = Path.resolve(pathToBlocksFolder, 'custom');
+import { getAllComponentManifests, getAllBlockManifests, getComponentDependencies, recursiveBuildProps } from '../../helpers/blocks';
 
 /**
  * Unit tests for get-option-colors.js helper
@@ -21,25 +16,13 @@ const pathToBlocks = Path.resolve(pathToBlocksFolder, 'custom');
  */
 it('tests block registration properly inherits all component attributes', () => {
 
-	const blockDirs = readdirSync(pathToBlocks);
-	const blockManifests = blockDirs.map((blockDir) => {
-		const manifestPath = Path.resolve(pathToBlocks, blockDir, 'manifest.json');
-		const manifest = JSON.parse(readFileSync(manifestPath));
-		return manifest;
-	});
-
-	const componentDirs = readdirSync(pathToComponents);
-	const componentManifests = componentDirs.map((componentDir) => {
-		const manifestPath = Path.resolve(pathToComponents, componentDir, 'manifest.json');
-		const manifest = JSON.parse(readFileSync(manifestPath));
-		return manifest;
-	});
-
+	const componentManifests = getAllComponentManifests();
+	const blockManifests = getAllBlockManifests();
 
 	// Build an array of expected attributes in each block.
 	buildWindowObject(globalManifest, componentManifests, blockManifests, wrapperManifest);
 
-	let blocks = [];
+	// Test all block manifests.
 	for (const blockManifest of blockManifests) {
 		const blockName = blockManifest.blockName;
 		const attributeNames = Object.keys(getAttributes(globalManifest, wrapperManifest, componentManifests, blockManifest));
@@ -56,7 +39,7 @@ it('tests block registration properly inherits all component attributes', () => 
 
 		// Make sure the block does not contain nonExpected attributes
 		if (blockAttributes[blockName].notExpected) {
-			for(const notExpected of blockAttributes[blockName].notExpected) {
+			for (const notExpected of blockAttributes[blockName].notExpected) {
 				expect(attributeNames).not.toEqual(expect.arrayContaining([notExpected]));
 			}
 		}

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -77,8 +77,6 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 
 			// Find the correct subComponent
 			const subComponent = builtProps.subComponents.filter((subComponent) => subComponent.newName === componentKey);
-			console.log('Looking for', componentKey);
-			console.log(builtProps);
 
 			// Expect to find exactly 1 sub component
 			expect(
@@ -157,7 +155,6 @@ it('tests that props helper builds the attributes / prefix correctly for all blo
 
 		const components = getBlockDependencies(blockManifests, blockManifest.blockName);
 		for (const newName of Object.keys(components)) {
-			console.log('running for ', newName);
 			const realName = components[newName];
 			blockOutput.subComponents = [...blockOutput.subComponents, ...recursiveBuildProps(attributes, componentManifests, realName, newName, true)];
 		}

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -7,7 +7,7 @@ import wrapperManifest from '../../../blocks/init/src/Blocks/wrapper/manifest.js
 import globalManifest from '../../../blocks/init/src/Blocks/manifest.json';
 import { blockAttributes } from '../../data/block-attributes';
 import { expect } from '@jest/globals';
-import { getAllComponentManifests, getAllBlockManifests, getComponentDependencies, recursiveBuildProps } from '../../helpers/blocks';
+import { getAllComponentManifests, getAllBlockManifests, getComponentDependencies, recursiveBuildProps, getBlockDependencies } from '../../helpers/blocks';
 import { propsOutput } from '../../data/props-output';
 
 /**
@@ -28,7 +28,7 @@ const debugName = (builtProps) => {
  */
 const recursiveAssertProps = (expectedProps, builtProps) => {
 
-	// Some sanity checkcs
+	// Some sanity check
 	expect(
 		builtProps,
 		`Missing attributes key in built props for: ${debugName(builtProps)}`
@@ -47,15 +47,17 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 		expect(builtProps.attributes).not.toHaveProperty(notExpected);
 	}
 
-	// Check prefix
-	expect(
-		builtProps.attributes,
-		`Missing "prefix" key in built props for ${debugName(builtProps)}`
-	).toHaveProperty('prefix');
-	expect(
-		builtProps.attributes.prefix,
-		`Prefix key not correct when sending props to ${debugName(builtProps)}`
-	).toEqual(expectedProps.prefix);
+	// Check prefix (but only if expected)
+	if (expectedProps.prefix) {
+		expect(
+			builtProps.attributes,
+			`Missing "prefix" key in built props for ${debugName(builtProps)}`
+		).toHaveProperty('prefix');
+		expect(
+			builtProps.attributes.prefix,
+			`Prefix key not correct when sending props to ${debugName(builtProps)}`
+		).toEqual(expectedProps.prefix);
+	}
 
 	// Repeat if expected has subComponents
 	if (expectedProps.components && Object.keys(expectedProps.components).length > 0) {
@@ -63,16 +65,18 @@ const recursiveAssertProps = (expectedProps, builtProps) => {
 
 			// Expect built props has subComponents
 			expect(
-				buildProps,
+				builtProps,
 				`Missing "subComponents" key in built props for ${debugName(builtProps)}. Expecting one because this has subComponents defined in props-output.js`
 			).toHaveProperty('subComponents');
 			expect(
-				buildProps.subComponents,
+				builtProps.subComponents,
 				`"subComponents" key in built props empty for ${debugName(builtProps)}.`
 			).not.toEqual([]);
 
 			// Find the correct subComponent
 			const subComponent = builtProps.subComponents.filter((subComponent) => subComponent.newName === componentKey);
+			console.log('Looking for', componentKey);
+			console.log(builtProps);
 
 			// Expect to find exactly 1 sub component
 			expect(
@@ -149,8 +153,11 @@ it('tests that props helper builds the attributes / prefix correctly for all blo
 			subComponents: []
 		};
 
-		const components = getComponentDependencies(componentManifests, blockManifest.blockName);
+		const components = getBlockDependencies(blockManifests, blockManifest.blockName);
+		console.log('Running for block: ', blockManifest.blockName);
+		console.log(components);
 		for (const newName of Object.keys(components)) {
+			console.log('running for ', newName);
 			const realName = components[newName];
 			blockOutput.subComponents = [...blockOutput.subComponents, ...recursiveBuildProps(attributes, componentManifests, realName, newName, true)];
 		}

--- a/tests/unit/blocks/blockRegistration.test.js
+++ b/tests/unit/blocks/blockRegistration.test.js
@@ -45,3 +45,43 @@ it('tests block registration properly inherits all component attributes', () => 
 		}
 	}
 });
+
+it('tests that props helper builds the prefix correctly', () => {
+	const componentManifests = getAllComponentManifests();
+	const blockManifests = getAllBlockManifests();
+
+	// Build an array of expected attributes in each block.
+	buildWindowObject(globalManifest, componentManifests, blockManifests, wrapperManifest);
+
+	// Test all block manifests.
+	// for (const blockManifest of blockManifests) {
+	// 	const blockName = blockManifest.blockName;
+	// 	const attributes = getAttributes(globalManifest, wrapperManifest, componentManifests, blockManifest);
+
+	// 	new componentAttributes = {...props(attributes, camelize(blockName), '', true)};
+	// }
+
+	// TEMP
+	let testManifest = {};
+	for (const blockManifest of blockManifests) {
+		const blockName = blockManifest.blockName;
+
+		if (blockName === 'mock-blockquote') {
+			testManifest = blockManifest;
+			break;
+		}
+	}
+
+	const attributes = getAttributes(globalManifest, wrapperManifest, componentManifests, testManifest);
+
+	// Build props for the current component.
+	// const props = recursiveBuildProps(attributes, componentManifests, testManifest.blockName);
+	let props = [];
+	const components = getComponentDependencies(componentManifests, testManifest.blockName);
+	for (const newName of Object.keys(components)) {
+		const realName = components[newName];
+		props = [...props, ...recursiveBuildProps(attributes, componentManifests, realName, newName, true)]
+	}
+
+	console.log(props);
+});

--- a/tests/unit/scripts/editor/ucfirst.test.js
+++ b/tests/unit/scripts/editor/ucfirst.test.js
@@ -1,0 +1,12 @@
+import { ucfirst } from "../../../../scripts/editor";
+
+test.each([
+	{input: 'aaa', expected: 'Aaa'},
+	{input: 'snake_case', expected: 'Snake_case'},
+	{input: 'camelCase', expected: 'CamelCase'},
+	{input: '111numbers', expected: '111numbers'},
+	{input: '"$#!"$!"', expected: '"$#!"$!"'},
+	{input: '', expected: ''},
+])('tests ucfirst always returns the first letter %s', ({input, expected}) => {
+	expect(ucfirst(input)).toBe(expected);
+});


### PR DESCRIPTION
Setup JS tests for the following (currently will fail because props changes haven't been merged):
* Block registration and component attribute inheritance
* Props attribute generation on each lvl
* Both of these tests will automatically test all blocks defined in `src/init/Blocks` (actual blocks we have implemented) as well as `tests/data/src/Blocks` (mock block manifests we can use for testing some weird inheritance situations)

Block registration test
---
* We can manually define `expected` and `notExpected` attributes in each block inside `tests/data/block-attributes.js`

Props registration test
---
* We can manually define which attributes are expected / notExpected to be present in each lvl of block / component dependency tree as well as the new `prefix` attribute which is used to determine the `prefix` of the attribute we're settting in any lvl / component. This is done inside `tests/data/props-output` (will look if this can be automatically checked rather than having this pretty sizable object in there which is kind atedious to write for each component / block but this way at least we can manually set expectations for each lvl or we'll have to write tests for tests :D)