### PR TITLE
Make boilerplate repo configurable in cli

### DIFF
--- a/setup/create-wp-project/src/arguments.js
+++ b/setup/create-wp-project/src/arguments.js
@@ -43,6 +43,12 @@ const scriptArguments = {
     type: 'boolean',
     skipPrompt: true,
   },
+  eightshiftBoilerplateRepo: {
+    name: 'eightshiftBoilerplateRepo',
+    describe: 'Use this to override which eightshift-boilerplate repository is used.',
+    type: 'text',
+    skipPrompt: true,
+  },
   eightshiftBoilerplateBranch: {
     name: 'eightshiftBoilerplateBranch',
     describe: 'Use this to override which infinum/eightshift-boilerplate version is loaded (mainly used for testing).',

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -32,8 +32,8 @@ exports.handler = async (argv) => {
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
   const projectPath = path.join(fullPath, promptedInfo.package);
-  const boilerplateRepoUrl = argv.eightshiftBoilerplateRepo ?? 'https://github.com/infinum/eightshift-boilerplate.git'
-  const boilerplateRepoBranch = argv.eightshiftBoilerplateBranch ? argv.eightshiftBoilerplateBranch : ''
+  const boilerplateRepoUrl = argv.eightshiftBoilerplateRepo ?? 'https://github.com/infinum/eightshift-boilerplate.git';
+  const boilerplateRepoBranch = argv.eightshiftBoilerplateBranch ?? '';
 
   await installStep({
     describe: `${step}. Cloning repo`,

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -32,10 +32,12 @@ exports.handler = async (argv) => {
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
   const projectPath = path.join(fullPath, promptedInfo.package);
+  const boilerplateRepoUrl = argv.eightshiftBoilerplateRepo ?? 'https://github.com/infinum/eightshift-boilerplate.git'
+  const boilerplateRepoBranch = argv.eightshiftBoilerplateBranch ? argv.eightshiftBoilerplateBranch : ''
 
   await installStep({
     describe: `${step}. Cloning repo`,
-    thisHappens: cloneRepoTo('https://github.com/infinum/eightshift-boilerplate.git', projectPath, argv.eightshiftBoilerplateBranch ? argv.eightshiftBoilerplateBranch : ''),
+    thisHappens: cloneRepoTo(boilerplateRepoUrl, projectPath, boilerplateRepoBranch),
   });
   step++;
 


### PR DESCRIPTION
This PR introduces new CLI flag `--eightshiftBoilerplateRepo` that allows specifying custom Eightshift Boilerplate repository for testing external forks. Default repository remains the same (`https://github.com/infinum/eightshift-boilerplate.git`).

Example usage:
```bash
npx create-wp-project --eightshiftBoilerplateRepo https://github.com/djelic/eightshift-boilerplate.git
```