### PR TITLE
Set the subkey for each boilerplate plugin or theme

### DIFF
--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -533,8 +533,9 @@ export const registerBlocks = (
 	// Set componentsManifest to global window for usage in storybook.
 	if (typeof window?.['eightshift'] === 'undefined') {
 		window['eightshift'] = {}
-		window['eightshift'][process.env.VERSION] = componentsManifest;
 	}
+
+	window['eightshift'][process.env.VERSION] = componentsManifest;
 
 	// Iterate blocks to register.
 	blocksManifests.map((blockManifest) => {


### PR DESCRIPTION
Fixes a bug which happens when there's more than 1 boilerplate plugin / theme inside a project.