### PR TITLE
Fix for responsive variables mobile first

### DIFF
--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -342,36 +342,49 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
  */
 export const prepareVariableData = (globalBreakpoints) => {
 
+	const sortedGlobalBreakpoints = Object.entries(globalBreakpoints)
+		.sort((a, b) => {
+			return a[1] - b[1]; // Sort from the smallest to the largest breakpoint.
+		});
+
 	// Define the min and max arrays.
 	const min = [];
 	const max = [];
+	let minBreakpointValue = 0;
 
 	// Loop the global breakpoints and populate the data.
-	Object.values(globalBreakpoints).forEach((item) => {
+	Object.values(sortedGlobalBreakpoints).forEach(([item, value]) => {
 
 		// Initial inner object.
 		const itemObject = {
-			name: Object.keys(globalBreakpoints).find((key) => globalBreakpoints[key] === item),
-			value: item,
+			name: item,
+			value: value,
 			variable: [],
 		};
 
 		// Inner object for min values.
 		const itemObjectMin = {
-			type: 'min',
 			...itemObject,
+			type: 'min',
+			value: minBreakpointValue,
 		}
 
 		// Inner object for max values.
 		const itemObjectMax = {
-			type: 'max',
 			...itemObject,
+			type: 'max',
 		}
+
+		// Transfer value to a larger breakpoint.
+		minBreakpointValue = value;
 
 		// Push both min and max to the defined arrays.
 		min.push(itemObjectMin);
 		max.push(itemObjectMax);
 	})
+
+	// Pop largest breakpoint out of min array.
+	min.shift();
 
 	// Add default object to the top of the array.
 	min.unshift({
@@ -383,6 +396,9 @@ export const prepareVariableData = (globalBreakpoints) => {
 
 	// Reverse order of max array.
 	max.reverse();
+
+	// Throwout the largest.
+	max.shift();
 
 	// Add default object to the top of the array.
 	max.unshift({


### PR DESCRIPTION
Changelog:
- added sort of global breakpoints in output CSS vars function
- corrected output for mobile first

Screenshots:
![MIN FIRST spacing bottom in](https://user-images.githubusercontent.com/46056662/126171151-3d4faa8d-cc16-42e3-bb8f-e8c29d0ea122.png)
![MIN FIRST editor spacing bottom in](https://user-images.githubusercontent.com/46056662/126171157-68ab07f3-7a72-4891-a436-70576c215feb.png)
![MAX first editor spacing top in](https://user-images.githubusercontent.com/46056662/126171158-da40cd7d-3a7e-4184-bb5c-79a7c45d8e48.png)
![MAX first spacing top in](https://user-images.githubusercontent.com/46056662/126171164-22d06e8e-2156-4ab9-8cb9-c204be453b2d.png)


**What is corrected and how it used to be:**

![wrong](https://user-images.githubusercontent.com/46056662/126172148-f3d0377f-97c5-4e90-a6d7-54d8e8da9b32.png)