### PR TITLE
Set only variablesCustom, variablesEditor and variablesCustomEditor

### DIFF
--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -236,8 +236,13 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 		return '';
 	}
 
-	// Bailout if manifest is missing variables key.
-	if (!_.has(manifest, 'variables')) {
+	// Bailout if manifest is missing any of variables key.
+	if (
+		!_.has(manifest, 'variables') &&
+		!_.has(manifest, 'variablesEditor') &&
+		!_.has(manifest, 'variablesCustom') &&
+		!_.has(manifest, 'variablesCustomEditor')
+	) {
 		return '';
 	}
 
@@ -259,13 +264,16 @@ export const outputCssVariables = (attributes, manifest, unique, globalManifest)
 	// Check if component or block.
 	let name = manifest['componentClass'] ?? attributes['blockClass'];
 
-	// Iterate each responsiveAttribute from responsiveAttributes that appears in variables field.
-	if (responsiveAttributes) {
-		setVariablesToBreakpoints(attributes, setupResponsiveVariables(responsiveAttributes, variables), data, manifest);
-	}
+	if (variables) {
 
-	// Iterate each variable from variables field.
-	setVariablesToBreakpoints(attributes, variables, data, manifest);
+		// Iterate each responsiveAttribute from responsiveAttributes that appears in variables field.
+		if (responsiveAttributes) {
+			setVariablesToBreakpoints(attributes, setupResponsiveVariables(responsiveAttributes, variables), data, manifest);
+		}
+
+		// Iterate each variable from variables field.
+		setVariablesToBreakpoints(attributes, variables, data, manifest);
+	}
 
 	// Iterate each responsiveAttribute from responsiveAttributes that appears in variablesEditor field.
 	if (variablesEditor) {


### PR DESCRIPTION
Changelog:
- changed condition for bailout

I've noticed that one block couldn't publish only custom CSS variable(translating from wrapper variable to block variable one). So I made these changes to enable all of the prementioned variables.

Use case:
<img width="646" alt="Screen Shot 2021-07-20 at 9 18 02 AM" src="https://user-images.githubusercontent.com/46056662/126278360-b830f5be-3bea-45b8-bc2c-80867a247abe.png">

Screenshots:
![editor - var custom editor](https://user-images.githubusercontent.com/46056662/126278603-2ea97f03-f9b5-4194-85e5-a0e7a967fcce.png)
![editor -var editor](https://user-images.githubusercontent.com/46056662/126278605-592be0af-b2d8-4c87-a97f-282bf658baf3.png)
![editor - varcustom](https://user-images.githubusercontent.com/46056662/126278608-600a694c-b79e-46b5-9675-21584c31ee18.png)
![front - varcustom](https://user-images.githubusercontent.com/46056662/126278611-6d52ce5e-ee31-48f4-b185-077e272c6b31.png)


