### PR TITLE
Fix ColorPaletteCustom label not showing

### DIFF
--- a/scripts/components/color-palette-custom/color-palette-custom.js
+++ b/scripts/components/color-palette-custom/color-palette-custom.js
@@ -48,7 +48,7 @@ export const ColorPaletteCustom = withSelect((select, ownProps) => {
 
 	return (
 		<div className={baseClass}>
-			{label?.length > 0 &&
+			{label &&
 				<div className={`${baseClass}__label`}>{label}</div>
 			}
 			<ColorPalette
@@ -76,7 +76,7 @@ export const ColorPaletteCustom = withSelect((select, ownProps) => {
 				}}
 			/>
 
-			{help?.length > 0 &&
+			{help &&
 				<p className={`${baseClass}__help`}>{help}</p>
 			}
 		</div>


### PR DESCRIPTION
Title says it all :)
The check was set up with labels as strings, but we sometimes pass components to them.