### PR TITLE
Fixed webpack require error

### DIFF
--- a/webpack/project.js
+++ b/webpack/project.js
@@ -10,6 +10,16 @@ module.exports = (options) => {
 	const output = {
 		path: options.config.outputPath,
 		publicPath: options.config.publicPath,
+
+		// These 2 fix the error we were having on projects with both theme + plugin using boilerplate (for example
+		// theme + Eightshift Forms) where we would sometimes get the following error:
+		//
+		// applicationBlocks.js?ver=1.0.0:64 Uncaught (in promise) TypeError: Cannot read property 'call' of undefined
+    // at __webpack_require__
+		//
+		// Fix source: https://github.com/webpack/webpack/issues/959#issuecomment-546506221
+		library: '[name]',
+		umdNamedDefine: false,
 	};
 
 	// Load Application Entrypoint.

--- a/webpack/project.js
+++ b/webpack/project.js
@@ -15,7 +15,7 @@ module.exports = (options) => {
 		// theme + Eightshift Forms) where we would sometimes get the following error:
 		//
 		// applicationBlocks.js?ver=1.0.0:64 Uncaught (in promise) TypeError: Cannot read property 'call' of undefined
-    // at __webpack_require__
+		// at __webpack_require__
 		//
 		// Fix source: https://github.com/webpack/webpack/issues/959#issuecomment-546506221
 		library: '[name]',


### PR DESCRIPTION
These 2 fix the error we were having on projects with both theme + plugin using boilerplate (for example
theme + Eightshift Forms) where we would sometimes get the following error:

```
applicationBlocks.js?ver=1.0.0:64 Uncaught (in promise) TypeError: Cannot read property 'call' of undefined
at __webpack_require__
```

Fix source: https://github.com/webpack/webpack/issues/959#issuecomment-546506221