### PR TITLE
Fix for default breakpoints

### DIFF
--- a/scripts/editor/output-css-variables.js
+++ b/scripts/editor/output-css-variables.js
@@ -178,11 +178,11 @@ const setupResponsiveVariables = (responsiveAttributes, variables) => {
 /**
  * Setting defined variables to each breakpoint.
  *
- * @param {object} attributes					- Attributes fetched from manifest.
- * @param {object} variables					- Variables fetched from manifest.
- * @param {object} data								- Preset objects separated in breakpoints.
- * @param {array} manifest						- Component/block manifest data.
- * @param {object} defaultBreakpoints	- Default breakpoints for mobile/desktop first.
+ * @param {object} attributes         - Attributes fetched from manifest.
+ * @param {object} variables          - Variables fetched from manifest.
+ * @param {object} data               - Preset objects separated in breakpoints.
+ * @param {array} manifest            - Component/block manifest data.
+ * @param {object} defaultBreakpoints - Default breakpoints for mobile/desktop first.
  *
  * @return {object} Filled object with variables data separated in breakpoints.
  */


### PR DESCRIPTION
Editor Version of this:
https://github.com/infinum/eightshift-libs/pull/221#issue-695750537

Desc:
There's been an issue in a case where you put "breakpoint": "mobile" in mobile-first "mode" in responsive or the largest breakpoint in the inverse: true, desktop-first responsive "mode".

The issue is resolved by adding default breakpoints recognition. By recognizing the default breakpoint, the breakpoint is reset to value 'default' which allows the variable to be set in a 'default' mode by setting the breakpoint.


![Screen Shot 2021-07-23 at 12 05 59 PM](https://user-images.githubusercontent.com/46056662/126768990-8d41ff53-d2de-409f-ab5f-19b4721ec177.png)
![Screen Shot 2021-07-23 at 12 06 52 PM](https://user-images.githubusercontent.com/46056662/126768993-7557ac8a-7b54-4f03-8705-c438d69e4d17.png)
![Screen Shot 2021-07-23 at 12 07 53 PM](https://user-images.githubusercontent.com/46056662/126768996-b37d1cb9-5873-4ae2-b53f-e29363931905.png)
![Screen Shot 2021-07-23 at 12 08 23 PM](https://user-images.githubusercontent.com/46056662/126768998-4a4a6153-9f2d-4403-b2c2-b49333496ff7.png)
![Screen Shot 2021-07-23 at 12 05 23 PM](https://user-images.githubusercontent.com/46056662/126769000-2c6ad628-6993-4e30-a0da-ab0889e69da3.png)
![Screen Shot 2021-07-23 at 12 04 53 PM](https://user-images.githubusercontent.com/46056662/126769002-6aaaedaf-db3f-42d5-a92e-c40ef147e526.png)
![Screen Shot 2021-07-23 at 12 04 14 PM](https://user-images.githubusercontent.com/46056662/126769030-9cbe30a6-b99e-4274-b661-4a976d7012f4.png)
