### PR TITLE
Fix phpstan issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.php]
+charset = utf-8
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,76 +1,114 @@
 name: Continuous integration checks
 
 on:
-    pull_request:
-        branches: [master, develop]
-    push:
-        branches: [master]
+  # Run on PRs and pushes, only on significant changes.
+  push:
+    branches:
+      - develop
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
-    lint:
-        name: File linting on Node v${{ matrix.node }}
-        runs-on: ubuntu-latest
+  lint:
+    name: File linting on Node v${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ 14, 15.x ]
 
-        strategy:
-            fail-fast: false
-            matrix:
-                node: [12, 14, 15.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
 
-            - name: Set Node.js version
-              uses: actions/setup-node@v1
-              with:
-                node-version: ${{ matrix.node }}
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
 
-            - name: Cache node modules
-              uses: actions/cache@v1
-              with:
-                path: node_modules
-                key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                  ${{ runner.OS }}-build-${{ env.cache-name }}-
-                  ${{ runner.OS }}-build-
-                  ${{ runner.OS }}-
+      - name: Install node packages
+        run: npm install
 
-            - name: Install node packages
-              run: npm install
+      - name: Run linters
+        run: npm run lint
 
-            - name: Run linters
-              run: npm run lint
+  phpcs:
+    name: PHPCS check on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.3', '7.4' ]
 
-    tests:
-        name: Jest - Unit tests
-        runs-on: ubuntu-latest
-        
-        strategy:
-            fail-fast: false
-            matrix:
-                node: [12, 14, 15.x]
+    steps:
+      # Checkout repository
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+      # Setup PHP versions, run checks
+      - name: PHP setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: cs2pr
 
-            - name: Set Node.js version
-              uses: actions/setup-node@v1
-              with:
-                node-version: ${{ matrix.node }}
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          dependency-versions: highest
 
-            - name: Cache node modules
-              uses: actions/cache@v1
-              with:
-                path: node_modules
-                key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                  ${{ runner.OS }}-build-${{ env.cache-name }}-
-                  ${{ runner.OS }}-build-
-                  ${{ runner.OS }}-
+      - name: Check coding standards using PHPCS
+        continue-on-error: true
+        run: composer standards:check -- --runtime-set testVersion ${{ matrix.php }}- --report-full --report-checkstyle=./phpcs-report.xml
 
-            - name: Install node packages
-              run: npm install
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml
 
-            - name: Run unit tests
-              run: npm run test:unit
+  phpstan:
+    name: PHPStan check
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allowed_failure }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.4' ]
+        allowed_failure: [ true ]
+
+    steps:
+      # Checkout repository
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Setup PHP versions, run checks
+      - name: PHP setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          dependency-versions: highest
+
+      - name: Check code consistency using PHPStan
+        run: composer analyze

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  # Run on PRs and pushes, only on significant changes.
+  push:
+    branches:
+      - develop
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  tests:
+    name: Jest - Unit tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [ 14, 15.x ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - name: Install node packages
+        run: npm install
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -11,6 +11,7 @@ use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 $manifest = Components::getManifest(__DIR__);
 
 $accordionUse = Components::checkAttr('accordionUse', $attributes, $manifest);
+
 if (!$accordionUse) {
 	return;
 }
@@ -53,7 +54,10 @@ $accordionClass = Components::classnames([
 		aria-hidden="<?php echo \esc_attr($accordionIsOpen ? 'false' : 'true'); ?>"
 	>
 		<div class="<?php echo \esc_attr("{$componentClass}__content"); ?>">
-			<?php echo \wp_kses_post($accordionContent); ?>
+			<?php
+				// @phpstan-ignore-next-line
+				echo $accordionContent; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			?>
 		</div>
 	</section>
 </div>

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -30,7 +30,7 @@ $buttonIsAnchor = Components::checkAttr('buttonIsAnchor', $attributes, $manifest
 $buttonId = Components::checkAttr('buttonId', $attributes, $manifest);
 $buttonIsNewTab = Components::checkAttr('buttonIsNewTab', $attributes, $manifest);
 $buttonAriaLabel = Components::checkAttr('buttonAriaLabel', $attributes, $manifest);
-$buttonAttrs = Components::checkAttr('buttonAttrs', $attributes, $manifest);
+$buttonAttrs = (array)Components::checkAttr('buttonAttrs', $attributes, $manifest);
 
 if ($buttonIsNewTab) {
 	$buttonAttrs = array_merge(

--- a/blocks/init/src/Blocks/components/copyright/copyright.php
+++ b/blocks/init/src/Blocks/components/copyright/copyright.php
@@ -32,5 +32,5 @@ $copyrightClass = Components::classnames([
 
 ?>
 <div class="<?php echo \esc_attr($copyrightClass); ?>">
-	<?php echo \esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); ?>
+	<?php echo \esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); // @phpstan-ignore-line Known bug. ?>
 </div>

--- a/blocks/init/src/Blocks/components/heading/heading.php
+++ b/blocks/init/src/Blocks/components/heading/heading.php
@@ -30,7 +30,7 @@ $headingClass = Components::classnames([
 	Components::selector($additionalClass, $additionalClass),
 ]);
 
-$headingLevel = $headingLevel ? "h{$headingLevel}" : 'h2';
+$headingLevel = $headingLevel ? "h{$headingLevel}" : 'h2'; // @phpstan-ignore-line Known bug.
 
 $unique = Components::getUnique();
 ?>

--- a/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
+++ b/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
@@ -61,19 +61,28 @@ $columnRightClass = Components::classnames([
 
 		<?php if ($layoutThreeColumnsLeft) { ?>
 			<div class="<?php echo \esc_attr($columnLeftClass); ?>">
-				<?php echo Components::ensureString($layoutThreeColumnsLeft); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php
+					// @phpstan-ignore-next-line
+					echo Components::ensureString($layoutThreeColumnsLeft); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
 			</div>
 		<?php } ?>
 
 		<?php if ($layoutThreeColumnsCenter) { ?>
 			<div class="<?php echo \esc_attr($columnCenterClass); ?>">
-				<?php echo Components::ensureString($layoutThreeColumnsCenter); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php
+					// @phpstan-ignore-next-line
+					echo Components::ensureString($layoutThreeColumnsCenter); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
 			</div>
 		<?php } ?>
 
 		<?php if ($layoutThreeColumnsRight) { ?>
 			<div class="<?php echo \esc_attr($columnRightClass); ?>">
-				<?php echo Components::ensureString($layoutThreeColumnsRight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php
+					// @phpstan-ignore-next-line
+					echo Components::ensureString($layoutThreeColumnsRight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
 			</div>
 		<?php } ?>
 

--- a/blocks/init/src/Blocks/components/menu/menu.php
+++ b/blocks/init/src/Blocks/components/menu/menu.php
@@ -26,7 +26,7 @@ $parentClasses = Components::classnames([
 	$jsClass ? "js-{$jsClass}" : '',
 ]);
 
-$bemMenu = Menu::bemMenu(
+$bemMenu = Menu::bemMenu( // @phpstan-ignore-line will be fixed in the stubs.
 	$name,
 	$variation,
 	$parentClasses,

--- a/blocks/init/src/Blocks/components/social-links/social-links.php
+++ b/blocks/init/src/Blocks/components/social-links/social-links.php
@@ -29,18 +29,29 @@ $socialLinksClass = Components::classnames([
 ]);
 ?>
 <ul class="<?php echo \esc_html($socialLinksClass); ?>">
-	<?php foreach ($socialLinksItems as $socialLink) { ?>
+	<?php
+	if (!is_iterable($socialLinksItems)) {
+		return;
+	}
+
+	foreach ($socialLinksItems as $socialLink) { ?>
 		<?php
 		$href = $socialLink['href'] ?? '';
 		$icon = $socialLink['icon'] ?? '';
-		$title = $socialLink['title'] ?? '';
+		$linkTitle = $socialLink['title'] ?? '';
 
 		if (empty($href) || empty($icon) || ! isset($icons[$icon])) {
 			continue;
 		}
 		?>
 		<li class="<?php echo \esc_html("{$componentClass}__item"); ?>">
-			<a class="<?php echo \esc_html("{$componentClass}__link"); ?>" href="<?php echo esc_url($href); ?>" title="<?php echo esc_attr($title); ?>" target="_blank" rel="nofollow noopener">
+			<a
+				class="<?php echo \esc_html("{$componentClass}__link"); ?>"
+				href="<?php echo esc_url($href); ?>"
+				title="<?php echo esc_attr($linkTitle); ?>"
+				target="_blank"
+				rel="nofollow noopener"
+			>
 				<?php echo $manifest['icons'][$icon]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</a>
 		</li>

--- a/blocks/init/src/Blocks/components/video/video.php
+++ b/blocks/init/src/Blocks/components/video/video.php
@@ -6,12 +6,13 @@
  * @package EightshiftBoilerplate
  */
 
-use EightshiftBoilerplate\EightshiftLibs\Helpers\Components;
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 
 $manifest = Components::getManifest(__DIR__);
 $componentName = $attributes['componentName'] ?? $manifest['componentName'];
 
-$videoUse = Components::checkAttr('videoUse', $attributes, $manifest, $componentName);
+$videoUse = Components::checkAttr('videoUse', $attributes, $manifest);
+
 if (!$videoUse) {
 	return;
 }
@@ -54,7 +55,12 @@ if (!$videoUrl) {
 	preload="<?php echo \esc_attr($videoPreload); ?>"
 	poster="<?php echo \esc_attr($videoPoster); ?>"
 >
-	<?php foreach ($videoUrl as $item) { ?>
+	<?php
+	if (!is_iterable($videoUrl)) {
+		return;
+	}
+
+	foreach ($videoUrl as $item) { ?>
 		<?php
 		$url = $item['url'] ?? '';
 		$mime = $item['mime'] ?? '';

--- a/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
+++ b/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
@@ -16,15 +16,15 @@ $featuredCategoriesQuery = Components::checkAttr('featuredCategoriesQuery', $att
 $featuredCategoriesItemsPerLine = Components::checkAttr('featuredCategoriesItemsPerLine', $attributes, $manifest);
 $featuredCategoriesServerSideRender = Components::checkAttr('featuredCategoriesServerSideRender', $attributes, $manifest);
 
-$taxonomy = $featuredCategoriesQuery['taxonomy'] ?? '';
+$taxonomyName = $featuredCategoriesQuery['taxonomy'] ?? '';
 
-if (!$taxonomy) {
+if (!$taxonomyName) {
 	return;
 }
 ?>
 
 <div
-	class="<?php echo esc_attr($blockClass); ?>"
+	class="<?php echo \esc_attr($blockClass); ?>"
 	data-items-per-line=<?php echo \esc_attr($featuredCategoriesItemsPerLine); ?>
 >
 	<?php
@@ -33,26 +33,30 @@ if (!$taxonomy) {
 
 	$args = [
 		'hide_empty' => false,
-		'taxonomy' => $taxonomy,
+		'taxonomy' => $taxonomyName,
 		'orderby' => 'include',
 		'include' => array_map(
 			function ($item) {
-				return $item['value'];
+				return $item['value']; // @phpstan-ignore-line
 			},
-			$terms
+			(array)$terms
 		),
 	];
 
 	$allTerms = \get_terms($args);
 
-	foreach ($allTerms as $term) {
+	if (!is_iterable($allTerms)) {
+		return;
+	}
+
+	foreach ($allTerms as $termObject) {
 		$cardProps = [
 			'imageUse' => false,
 			'introUse' => false,
-			'headingContent' => $term->name,
-			'paragraphContent' => $term->description,
+			'headingContent' => is_object($termObject) ? $termObject->name : '',
+			'paragraphContent' => is_object($termObject) ? $termObject->description : '',
 			'buttonContent' => __('Show More', 'eightshift-frontend-libs'),
-			'buttonUrl' => \get_term_link($term),
+			'buttonUrl' => \get_term_link($termObject),
 		];
 
 		if ($featuredCategoriesServerSideRender) {

--- a/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
+++ b/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
@@ -27,27 +27,28 @@ global $post;
 	data-items-per-line=<?php echo \esc_attr($featuredPostsItemsPerLine); ?>
 >
 	<?php
-		$postType = $featuredPostsQuery['postType'] ?? '';
-		$taxonomy = $featuredPostsQuery['taxonomy'] ?? '';
-		$terms = $featuredPostsQuery['terms'] ?? [];
-		$posts = $featuredPostsQuery['posts'] ?? [];
+		$postType = $featuredPostsQuery['postType'] ?? ''; // @phpstan-ignore-line
+		$selectedTaxonomy = $featuredPostsQuery['taxonomy'] ?? '';
+		$termList = $featuredPostsQuery['terms'] ?? [];
+		$postList = $featuredPostsQuery['posts'] ?? [];
 
 		$args = [
 			'post_type' => $postType,
 			'posts_per_page' => $featuredPostsShowItems,
 		];
 
-		if ($taxonomy) {
+		if ($selectedTaxonomy) {
 			$args['tax_query'][0] = [
-				'taxonomy' => $taxonomy,
+				'taxonomy' => $selectedTaxonomy,
 				'field' => 'id',
 			];
-			if ($terms) {
+
+			if ($termList) {
 				$args['tax_query'][0]['terms'] = array_map(
 					function ($item) {
-						return $item['value'];
+						return $item['value']; // @phpstan-ignore-line
 					},
-					$terms
+					(array)$termList
 				);
 			} else {
 				$args['tax_query'][0]['operator'] = 'NOT IN'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -58,23 +59,23 @@ global $post;
 			$args['post__not_in'] = [$post->ID];
 		}
 
-		if ($posts) {
+		if ($postList) {
 			$args['post__in'] = array_map(
 				function ($item) {
-					return $item['value'];
+					return $item['value']; // @phpstan-ignore-line
 				},
-				$posts
+				(array)$postList
 			);
 			$args['orderby'] = 'post__in';
 		}
 
-		$theQuery = new \WP_Query($args);
+		$mainQuery = new \WP_Query($args);
 
-		if ($theQuery->have_posts()) {
-			while ($theQuery->have_posts()) {
-				$theQuery->the_post();
+		if ($mainQuery->have_posts()) {
+			while ($mainQuery->have_posts()) {
+				$mainQuery->the_post();
 
-				$postId = get_the_ID();
+				$postId = \get_the_ID();
 
 				$image = \get_the_post_thumbnail_url($postId, 'large');
 

--- a/blocks/init/src/Blocks/custom/video/video.php
+++ b/blocks/init/src/Blocks/custom/video/video.php
@@ -6,7 +6,7 @@
  * @package EightshiftBoilerplate
  */
 
-use EightshiftBoilerplate\EightshiftLibs\Helpers\Components;
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 
 $globalManifest = Components::getManifest(dirname(__DIR__, 2));
 $manifest = Components::getManifest(__DIR__);

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -14,10 +14,13 @@ $manifest = Components::getManifest(__DIR__);
 $wrapperUse = Components::checkAttr('wrapperUse', $attributes, $manifest);
 $wrapperUseSimple = Components::checkAttr('wrapperUseSimple', $attributes, $manifest);
 $wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest);
-$wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
 $className = Components::checkAttr('className', $attributes, $manifest);
 
 if (! $wrapperUse || $wrapperDisable) {
+	$wrapperParentClass = is_string(Components::checkAttr('wrapperParentClass', $attributes, $manifest)) ?
+		Components::checkAttr('wrapperParentClass', $attributes, $manifest) :
+		'';
+
 	if ($wrapperParentClass) {
 		?>
 			<div class="<?php echo \esc_attr($wrapperParentClass . '__item'); ?>">
@@ -150,7 +153,7 @@ $wrapperInnerClass = Components::classnames([
 ]);
 
 ?>
-<div class="<?php echo \esc_attr($wrapperClass); ?>" <?php echo \esc_attr(($wrapperId) ? 'id=" ' . $wrapperId . '"' : ''); ?>>
+<div class="<?php echo \esc_attr($wrapperClass); ?>" <?php echo \esc_attr($wrapperId ? 'id=" ' . $wrapperId . '"' : ''); ?>>
 
 	<?php if ($wrapperAnchorId) { ?>
 		<div class="<?php echo \esc_attr("{$wrapperMainClass}__anchor"); ?>" id="<?php echo \esc_attr($wrapperAnchorId); ?>"></div>

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,16 @@
 		"source": "https://github.com/infinum/eightshift-frontend-libs"
 	},
 	"require": {
-		"php": ">=7.2",
+		"php": "^7.3 || <8.0",
 		"ext-json": "*",
 		"php-di/php-di": "^6.3.2"
 	},
 	"require-dev": {
-		"infinum/eightshift-coding-standards": "^1.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-		"szepeviktor/phpstan-wordpress": "^0.7",
-		"php-stubs/wordpress-stubs": "^5.7"
+		"infinum/eightshift-coding-standards": "^1.3",
+		"infinum/eightshift-libs-stubs": "^0.2.0",
+		"php-stubs/wordpress-stubs": "^5.7",
+		"szepeviktor/phpstan-wordpress": "^0.7"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,7 +7,6 @@
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/src/commands/templates/*</exclude-pattern>
 
 	<!-- Additional arguments. -->
 	<arg value="sp"/>
@@ -16,42 +15,12 @@
 	<arg name="cache"/>
 	<arg name="extensions" value="php"/>
 
-	<file>.</file>
-
-	<exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
-
-	<rule ref="WordPress.PHP.DiscouragedPHPFunctions.system_calls_system">
-		<exclude-pattern>*/src/**/*Cli</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents">
-		<exclude-pattern>*/src/**/*Cli</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec">
-		<exclude-pattern>*/src/Db/*</exclude-pattern>
-		<exclude-pattern>*/src/Build/*</exclude-pattern>
-		<exclude-pattern>*/cliOutput/bin/Build.php</exclude-pattern>
-		<exclude-pattern>*/src/LintPhp/LintPhpCli.php</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fopen">
-		<exclude-pattern>*/src/Cli/*</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fwrite">
-		<exclude-pattern>*/src/Cli/*</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.WP.AlternativeFunctions.file_system_read_fclose">
-		<exclude-pattern>*/src/Cli/*</exclude-pattern>
-	</rule>
+	<file>blocks/init/src</file>
 
 	<rule ref="Generic.Files.LineLength">
-		<exclude name="Generic.Files.LineLength.TooLong"/>
-	</rule>
-
-	<rule ref="WordPress.WP.GlobalVariablesOverride">
-		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
+		<properties>
+			<property name="lineLimit" value="180" />
+			<property name="ignoreComments" value="true" />
+		</properties>
 	</rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,6 @@ parameters:
 		# Ignore errors about reflection class variable being undefined. Errors are caught.
 		- '/^Variable (\$attributes|\$innerBlockContent|\$this|\$templatePath|\$reflectionClass) might not be defined\.$/'
 		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (esc_attr|esc_html|esc_url|wp_kses_post) expects string, [a-zA-Z0-9\_\|<>]+ given\.$/'
-		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (get_the_post_thumbnail_url|get_the_title|get_the_excerpt|get_the_permalink) expects int|WP_Post|null, [a-zA-Z0-9\_\|<>]+ given\.$/'
-		- "/^Cannot access offset '[$a-z0-9]+' on [a-zA-Z0-9_|<>]+.$/"
-		- "/^Cannot assign offset '[$a-z0-9]+' to string.$/"
+		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (get_the_post_thumbnail_url|get_the_title|get_the_excerpt|get_the_permalink) expects int\|WP_Post\|null, [a-zA-Z0-9\_\|<>]+ given\.$/'
+		- "/^Cannot access offset '[\\$a-z0-9]+' on [a-zA-Z0-9_|<>]+.$/"
+		- "/^Cannot assign offset '[\\$a-z0-9]+' to string.$/"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,17 @@
+includes:
+	- vendor/szepeviktor/phpstan-wordpress/extension.neon
+parameters:
+	level: max
+	inferPrivatePropertyTypeFromConstructor: true
+	treatPhpDocTypesAsCertain: false
+	bootstrapFiles:
+		- %currentWorkingDirectory%/vendor/infinum/eightshift-libs-stubs/eightshift-libs-stubs.php
+	paths:
+		- blocks/init/src/
+	ignoreErrors:
+		# Ignore errors about reflection class variable being undefined. Errors are caught.
+		- '/^Variable (\$attributes|\$innerBlockContent|\$this|\$templatePath|\$reflectionClass) might not be defined\.$/'
+		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (esc_attr|esc_html|esc_url|wp_kses_post) expects string, [a-zA-Z0-9\_\|<>]+ given\.$/'
+		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (get_the_post_thumbnail_url|get_the_title|get_the_excerpt|get_the_permalink) expects int|WP_Post|null, [a-zA-Z0-9\_\|<>]+ given\.$/'
+		- "/^Cannot access offset '[$a-z0-9]+' on [a-zA-Z0-9_|<>]+.$/"
+		- "/^Cannot assign offset '[$a-z0-9]+' to string.$/"


### PR DESCRIPTION
I've fixed some of the PHPStanand PHPCS issues in the blocks, there are still some that are present from PHPStan. Some are false positives, some will be gone, once we release the libs with the [updated fixes](https://github.com/infinum/eightshift-libs/pull/224) and type hints. 

I've also created [stubs](https://github.com/infinum/eightshift-libs-stubs) for the FE libs (mostly for the helpers that are used in the FE libs). The stubs will need to be updated once the libs are updated so that they stay up to date.

I've also split the checks and tests for the actions and added PHPStanand PHPCS for the block view files.

And fixed as much as possible.

PHPStan checks will fail, but I've set them to be allowed failures (since most are false positives because of how the helpers in PHP are written).