### PR TITLE
Remove phpstan ignore comments

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -73,7 +73,7 @@ $accordionContentClass = Components::selector($componentClass, $componentClass, 
 		<div class="<?php echo \esc_attr($accordionContentClass); ?>">
 			<?php
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo $accordionContent; // @phpstan-ignore-line
+				echo $accordionContent;
 			?>
 		</div>
 	</section>

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -46,7 +46,6 @@ $buttonClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
-	// @phpstan-ignore-next-line
 	Components::selector($buttonIsAnchor, 'js-scroll-to-anchor'),
 ]);
 

--- a/blocks/init/src/Blocks/components/copyright/copyright.php
+++ b/blocks/init/src/Blocks/components/copyright/copyright.php
@@ -32,5 +32,5 @@ $copyrightClass = Components::classnames([
 
 ?>
 <div class="<?php echo \esc_attr($copyrightClass); ?>">
-	<?php echo \esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); // @phpstan-ignore-line Known bug. ?>
+	<?php echo \esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); ?>
 </div>

--- a/blocks/init/src/Blocks/components/drawer/drawer.php
+++ b/blocks/init/src/Blocks/components/drawer/drawer.php
@@ -31,7 +31,6 @@ $drawerClass = Components::classnames([
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
 	Components::selector($componentJsClass, $componentJsClass),
-	// @phpstan-ignore-next-line
 	Components::selector($drawerPosition, $componentClass, 'position', $drawerPosition),
 ]);
 

--- a/blocks/init/src/Blocks/components/heading/heading.php
+++ b/blocks/init/src/Blocks/components/heading/heading.php
@@ -30,7 +30,7 @@ $headingClass = Components::classnames([
 	Components::selector($additionalClass, $additionalClass),
 ]);
 
-$headingLevel = $headingLevel ? "h{$headingLevel}" : 'h2'; // @phpstan-ignore-line Known bug.
+$headingLevel = $headingLevel ? "h{$headingLevel}" : 'h2';
 
 $unique = Components::getUnique();
 ?>

--- a/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
+++ b/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
@@ -56,7 +56,6 @@ $columnRightClass = Components::classnames([
 		<?php if ($layoutThreeColumnsLeft) { ?>
 			<div class="<?php echo \esc_attr($columnLeftClass); ?>">
 				<?php
-					// @phpstan-ignore-next-line
 					echo Components::ensureString($layoutThreeColumnsLeft); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</div>
@@ -65,7 +64,6 @@ $columnRightClass = Components::classnames([
 		<?php if ($layoutThreeColumnsCenter) { ?>
 			<div class="<?php echo \esc_attr($columnCenterClass); ?>">
 				<?php
-					// @phpstan-ignore-next-line
 					echo Components::ensureString($layoutThreeColumnsCenter); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</div>
@@ -74,7 +72,6 @@ $columnRightClass = Components::classnames([
 		<?php if ($layoutThreeColumnsRight) { ?>
 			<div class="<?php echo \esc_attr($columnRightClass); ?>">
 				<?php
-					// @phpstan-ignore-next-line
 					echo Components::ensureString($layoutThreeColumnsRight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</div>

--- a/blocks/init/src/Blocks/components/loader/loader.php
+++ b/blocks/init/src/Blocks/components/loader/loader.php
@@ -26,7 +26,6 @@ $loaderClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
-	// @phpstan-ignore-next-line
 	Components::selector($loaderUseOverlay, $componentClass, '', 'use-overlay'),
 ]);
 ?>

--- a/blocks/init/src/Blocks/components/menu/menu.php
+++ b/blocks/init/src/Blocks/components/menu/menu.php
@@ -26,7 +26,7 @@ $parentClasses = Components::classnames([
 	$jsClass ? "js-{$jsClass}" : '',
 ]);
 
-$bemMenu = Menu::bemMenu( // @phpstan-ignore-line will be fixed in the stubs.
+$bemMenu = Menu::bemMenu(
 	$name,
 	$variation,
 	$parentClasses,

--- a/blocks/init/src/Blocks/components/menu/menu.php
+++ b/blocks/init/src/Blocks/components/menu/menu.php
@@ -26,7 +26,7 @@ $parentClasses = Components::classnames([
 	$jsClass ? "js-{$jsClass}" : '',
 ]);
 
-$bemMenu = Menu::bemMenu(
+$bemMenu = Menu::bemMenu( // @phpstan-ignore-line will be fixed in the stubs.
 	$name,
 	$variation,
 	$parentClasses,

--- a/blocks/init/src/Blocks/components/video/video.php
+++ b/blocks/init/src/Blocks/components/video/video.php
@@ -65,7 +65,7 @@ if (!$videoUrl) {
 		$url = $item['url'] ?? '';
 		$mime = $item['mime'] ?? '';
 
-		if ($url && $mime) { // @phpstan-ignore-line ?>
+		if ($url && $mime) { ?>
 			<source src="<?php echo esc_url($url); ?>" type="<?php echo esc_attr($mime); ?>" />
 		<?php } ?>
 	<?php } ?>

--- a/blocks/init/src/Blocks/custom/carousel/carousel.php
+++ b/blocks/init/src/Blocks/custom/carousel/carousel.php
@@ -45,7 +45,7 @@ $paginationClass = Components::classnames([
 <div
 	class="<?php echo esc_attr($carouselClass); ?>"
 	data-swiper-loop="<?php echo esc_attr($carouselIsLoop ? 'true' : 'false'); ?>"
-	data-show-items="<?php echo esc_attr($carouselShowItems); // @phpstan-ignore-line ?>"
+	data-show-items="<?php echo esc_attr($carouselShowItems); ?>"
 >
 	<div class="<?php echo esc_attr('swiper-wrapper'); ?>">
 		<?php echo $innerBlockContent; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
+++ b/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
@@ -41,7 +41,7 @@ if (!$taxonomyName) {
 		'orderby' => 'include',
 		'include' => array_map(
 			function ($item) {
-				return $item['value']; // @phpstan-ignore-line
+				return $item['value'];
 			},
 			(array)$terms
 		),

--- a/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
+++ b/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
@@ -33,7 +33,7 @@ global $post;
 	<?php
 		echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		$postType = $featuredPostsQuery['postType'] ?? ''; // @phpstan-ignore-line
+		$postType = $featuredPostsQuery['postType'] ?? '';
 		$selectedTaxonomy = $featuredPostsQuery['taxonomy'] ?? '';
 		$termList = $featuredPostsQuery['terms'] ?? [];
 		$postList = $featuredPostsQuery['posts'] ?? [];
@@ -52,7 +52,7 @@ global $post;
 			if ($termList) {
 				$args['tax_query'][0]['terms'] = array_map(
 					function ($item) {
-						return $item['value']; // @phpstan-ignore-line
+						return $item['value'];
 					},
 					(array)$termList
 				);
@@ -68,7 +68,7 @@ global $post;
 		if ($postList) {
 			$args['post__in'] = array_map(
 				function ($item) {
-					return $item['value']; // @phpstan-ignore-line
+					return $item['value'];
 				},
 				(array)$postList
 			);

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -17,8 +17,8 @@ $wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest
 $wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
 $className = Components::checkAttr('className', $attributes, $manifest);
 
-$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item'); // @phpstan-ignore-line
-$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner'); // @phpstan-ignore-line
+$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item');
+$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
 
 if (!$wrapperUse || $wrapperDisable) {
 	if ($wrapperParentClass) {

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -17,8 +17,8 @@ $wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest
 $wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
 $className = Components::checkAttr('className', $attributes, $manifest);
 
-$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item'); // @phpstan-ignore-line
-$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner'); // @phpstan-ignore-line
+$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item');
+$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
 
 if (!$wrapperUse || $wrapperDisable) {
 	if ($wrapperParentClass) {
@@ -62,35 +62,32 @@ $wrapperOffset = Components::checkAttrResponsive('wrapperOffset', $attributes, $
 
 $componentClass = 'wrapper';
 
-// @phpstan-ignore-next-line
 $wrapperClass = Components::classnames([
 	$componentClass,
-	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperSpacingBottomIn, 'spacing-bottom-in', $componentClass), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperDividerTop, 'divider-top', $componentClass, false), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperDividerBottom, 'divider-bottom', $componentClass, false), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperHide, 'hide', $componentClass, false), // @phpstan-ignore-line
+	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor),
+	Components::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass),
+	Components::responsiveSelectors($wrapperSpacingBottomIn, 'spacing-bottom-in', $componentClass),
+	Components::responsiveSelectors($wrapperDividerTop, 'divider-top', $componentClass, false),
+	Components::responsiveSelectors($wrapperDividerBottom, 'divider-bottom', $componentClass, false),
+	Components::responsiveSelectors($wrapperHide, 'hide', $componentClass, false),
 	$className,
 ]);
 
 $wrapperContainerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'container'), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass), // @phpstan-ignore-line
-	// @phpstan-ignore-next-line
+	Components::selector($componentClass, $componentClass, 'container'),
+	Components::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass),
 	Components::responsiveSelectors($wrapperGutter, 'gutter', $componentClass),
 ]);
 
 $wrapperInnerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'inner'), // @phpstan-ignore-line
-	Components::responsiveSelectors($wrapperWidth, 'width', $componentClass), // @phpstan-ignore-line
-	// @phpstan-ignore-next-line
+	Components::selector($componentClass, $componentClass, 'inner'),
+	Components::responsiveSelectors($wrapperWidth, 'width', $componentClass),
 	Components::responsiveSelectors($wrapperOffset, 'offset', $componentClass),
 ]);
 
-$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor'); // @phpstan-ignore-line
+$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor');
 
 $idOutput = '';
 

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -17,8 +17,8 @@ $wrapperDisable = Components::checkAttr('wrapperDisable', $attributes, $manifest
 $wrapperParentClass = Components::checkAttr('wrapperParentClass', $attributes, $manifest);
 $className = Components::checkAttr('className', $attributes, $manifest);
 
-$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item');
-$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner');
+$wrapperParentClassItemClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item'); // @phpstan-ignore-line
+$wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $wrapperParentClass, 'item-inner'); // @phpstan-ignore-line
 
 if (!$wrapperUse || $wrapperDisable) {
 	if ($wrapperParentClass) {
@@ -64,7 +64,7 @@ $componentClass = 'wrapper';
 
 $wrapperClass = Components::classnames([
 	$componentClass,
-	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor),
+	Components::selector($componentClass, $componentClass, 'bg-color', $wrapperBackgroundColor), // @phpstan-ignore-line
 	Components::responsiveSelectors($wrapperSpacingTop, 'spacing-top', $componentClass),
 	Components::responsiveSelectors($wrapperSpacingBottom, 'spacing-bottom', $componentClass),
 	Components::responsiveSelectors($wrapperSpacingTopIn, 'spacing-top-in', $componentClass),
@@ -76,18 +76,18 @@ $wrapperClass = Components::classnames([
 ]);
 
 $wrapperContainerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'container'),
+	Components::selector($componentClass, $componentClass, 'container'), // @phpstan-ignore-line
 	Components::responsiveSelectors($wrapperContainerWidth, 'container-width', $componentClass),
 	Components::responsiveSelectors($wrapperGutter, 'gutter', $componentClass),
 ]);
 
 $wrapperInnerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass, 'inner'),
+	Components::selector($componentClass, $componentClass, 'inner'), // @phpstan-ignore-line
 	Components::responsiveSelectors($wrapperWidth, 'width', $componentClass),
 	Components::responsiveSelectors($wrapperOffset, 'offset', $componentClass),
 ]);
 
-$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor');
+$wrapperMainAnchorClass = Components::selector($componentClass, $componentClass, 'anchor'); // @phpstan-ignore-line
 
 $idOutput = '';
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,7 +11,4 @@ parameters:
 	ignoreErrors:
 		# Ignore errors about reflection class variable being undefined. Errors are caught.
 		- '/^Variable (\$attributes|\$innerBlockContent|\$this|\$templatePath|\$reflectionClass) might not be defined\.$/'
-		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (esc_attr|esc_html|esc_url|wp_kses_post) expects string, [a-zA-Z0-9\_\|<>]+ given\.$/'
 		- '/^Parameter \#1 [\$a-z0-9\_]+ of function (get_the_post_thumbnail_url|get_the_title|get_the_excerpt|get_the_permalink) expects int\|WP_Post\|null, [a-zA-Z0-9\_\|<>]+ given\.$/'
-		- "/^Cannot access offset '[\\$a-z0-9]+' on [a-zA-Z0-9_|<>]+.$/"
-		- "/^Cannot assign offset '[\\$a-z0-9]+' to string.$/"


### PR DESCRIPTION
Some PHPStan errors have been fixed [here](https://github.com/infinum/eightshift-libs-stubs/pull/4). Having `// @phpstan-ignore-line` in code will cause error since trying to ignore error which doesn't exist. I'm removing some so the tests could be clean.