### PR TITLE
update em() for better arithmetic support

### DIFF
--- a/styles/scss/functions/_em.scss
+++ b/styles/scss/functions/_em.scss
@@ -40,5 +40,5 @@
 $browser-context: $base-font-size;
 
 @function em($pixels, $context: $browser-context) {
-	@return #{math.div(strip-unit($pixels), strip-unit($context))}em;
+	@return math.div(strip-unit($pixels), strip-unit($context)) * 1em;
 }


### PR DESCRIPTION
When doing `npm run build` on one of the projects I am getting an error:

> SassError: Undefined operation "-1 * 0.5555555556em".
> margin: 0 (-1 * map-get-strict($the-posts, 'gutter'));

The problem seems to lie inside the `em() `function which returns interpolated value. The thing is that arithmetics don't perform well when handling interpolated strings. See [here](https://github.com/dlmanning/gulp-sass/issues/611#issuecomment-375320728)

```
@function em($pixels, $context: $browser-context) {
	@return #{math.div(strip-unit($pixels), strip-unit($context))}em; // shouldn't be interpolated
}
```