### PR TITLE
Remove console logs

### DIFF
--- a/scripts/components/option-picker/docs/story.js
+++ b/scripts/components/option-picker/docs/story.js
@@ -33,7 +33,7 @@ export const component = () => {
 	return (
 		<OptionPicker
 			value={'top'}
-			onChange={(value) => console.log(value)}
+			onChange={(value) => console.info(value)}
 			isToolbarButton={false}
 			isInToolbar={false}
 			options={demoOptions}
@@ -46,7 +46,7 @@ export const toolbarGroup = () => {
 	return (
 		<OptionPicker
 			value={'top'}
-			onChange={(value) => console.log(value)}
+			onChange={(value) => console.info(value)}
 			isToolbarButton={true}
 			isInToolbar={true}
 			options={demoOptions}
@@ -59,7 +59,7 @@ export const toolbarGroupInline = () => {
 	return (
 		<OptionPicker
 			value={'top'}
-			onChange={(value) => console.log(value)}
+			onChange={(value) => console.info(value)}
 			isToolbarButton={true}
 			isInToolbar={true}
 			isInline

--- a/scripts/components/simple-vertical-single-select/docs/readme.mdx
+++ b/scripts/components/simple-vertical-single-select/docs/readme.mdx
@@ -15,7 +15,7 @@ Each option should be in this format:
 
 ```js
 {
-	onClick: () => console.log('Clicked!'),
+	onClick: () => console.info('Clicked!'),
 	icon: icons.large, // Optional
 	label: 'Large',
 	isActive: myBoolean,

--- a/scripts/editor/override-inner-block-attributes.js
+++ b/scripts/editor/override-inner-block-attributes.js
@@ -36,7 +36,6 @@
 			for (const attribute in attributesObject) {
 				if (Object.prototype.hasOwnProperty.call(attributesObject, attribute)) {
 					if (attribute !== attributes[attribute]) {
-						console.log(attributes, attributesObject[attribute]);
 						attributes[attribute] = attributesObject[attribute];
 					}
 				}


### PR DESCRIPTION
In stories, the logs are replaced by info, and in one helper it was removed. It outputted tons of info in the console. 

This one slipped through our fingers. I noticed that the linters are not picking them up, and they should. So maybe we need to fix them to catch these cases.