### PR TITLE
Fix heading <-> paragraph transform issues

### DIFF
--- a/blocks/init/src/Blocks/custom/heading/heading-transforms.js
+++ b/blocks/init/src/Blocks/custom/heading/heading-transforms.js
@@ -8,9 +8,18 @@ export const transforms = {
 		{
 			type: 'block',
 			blocks: [`${manifest.namespace}/${manifestParagraph.blockName}`],
-			transform: ({ paragraph }) => (
-				createBlock(`${manifest.namespace}/${manifestHeading.blockName}`, { heading: paragraph })
-			),
+			transform: (attributes) => {
+				let headingAttributes = {};
+				for (const attribute in attributes) {
+					if (attribute.startsWith('block')) {
+						continue;
+					}
+					const attrKey = attribute.replace('paragraph', 'heading').replace('Paragraph', 'Heading');
+					headingAttributes[attrKey] = attributes[attribute];
+				}
+
+				return createBlock(`${manifest.namespace}/${manifestHeading.blockName}`, headingAttributes);
+			},
 		},
 	],
 };

--- a/blocks/init/src/Blocks/custom/paragraph/paragraph-transforms.js
+++ b/blocks/init/src/Blocks/custom/paragraph/paragraph-transforms.js
@@ -8,12 +8,17 @@ export const transforms = {
 		{
 			type: 'block',
 			blocks: [`${globalManifest.namespace}/${manifestHeading.blockName}`],
-			transform: ( { headingHeadingColor, headingHeadingContent, headingAlign } ) => {
-				return createBlock(`${globalManifest.namespace}/${manifestParagraph.blockName}`, {
-					paragraphParagraphColor: headingHeadingColor,
-					paragraphParagraphContent: headingHeadingContent,
-					paragraphAlign: headingAlign,
-				});
+			transform: (attributes) => {
+				let paragraphAttributes = {};
+				for (const attribute in attributes) {
+					if (attribute.startsWith('block')) {
+						continue;
+					}
+					const attrKey = attribute.replace('heading', 'paragraph').replace('Heading', 'Paragraph');
+					paragraphAttributes[attrKey] = attributes[attribute];
+				}
+
+				return createBlock(`${globalManifest.namespace}/${manifestParagraph.blockName}`, paragraphAttributes);
 			},
 		},
 		{


### PR DESCRIPTION
Fixes heading/paragraph transform issues by directly replacing component/block names in transforms. Skips attributes beginning with `block` (`blockName`, `blockClass` etc.)

An alternative approach would be to use the props helper to rename the component attributes as well or otherwise transform the components.