### PR TITLE
Babel "polyfill loaded twice" warning fix

### DIFF
--- a/blocks/init/assets/scripts/application.js
+++ b/blocks/init/assets/scripts/application.js
@@ -4,4 +4,6 @@
  * Usage: `WordPress frontend screen`.
  */
 
-import '@babel/polyfill';
+if (!window?._babelPolyfill) {
+	require('@babel/polyfill');
+}

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks.js
@@ -10,7 +10,7 @@
 import { dynamicImport } from '@eightshift/frontend-libs/scripts/helpers';
 
 if (!window?._babelPolyfill) {
-	import('@babel/polyfill');
+	require('@babel/polyfill');
 }
 
 // Find all blocks and require assets index.js inside it.

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks.js
@@ -9,8 +9,8 @@
  */
 import { dynamicImport } from '@eightshift/frontend-libs/scripts/helpers';
 
-if (!window._babelPolyfill) {
-	require('@babel/polyfill');
+if (!window?._babelPolyfill) {
+	import('@babel/polyfill');
 }
 
 // Find all blocks and require assets index.js inside it.

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks.js
@@ -9,7 +9,9 @@
  */
 import { dynamicImport } from '@eightshift/frontend-libs/scripts/helpers';
 
-import "@babel/polyfill";
+if (!window._babelPolyfill) {
+	require('@babel/polyfill');
+}
 
 // Find all blocks and require assets index.js inside it.
 dynamicImport(require.context('./../../components', true, /assets\/index\.js$/));


### PR DESCRIPTION
Fixes the
```
@babel/polyfill is loaded more than once on this page. This is probably not desirable/intended and may have consequences if different versions of the polyfills are applied sequentially. If you do need to load the polyfill more than once, use @babel/polyfill/noConflict instead to bypass the warning.
```
warning.