### PR TITLE
Paragraph fix

### DIFF
--- a/blocks/init/src/Blocks/custom/paragraph/components/paragraph-editor.js
+++ b/blocks/init/src/Blocks/custom/paragraph/components/paragraph-editor.js
@@ -30,7 +30,7 @@ export const ParagraphEditor = (keyProps) => {
 
 		return createBlock(blockFullName, {
 			...propsObject,
-			paragraphParagraphContent: value,
+			[`${propsObject.prefix}Content`]: value,
 		});
 	};
 

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -132,7 +132,11 @@ const getMergeCallback = (blockManifest) => {
 		return (receiver, merger) => {
 			let outputObject = {};
 
-			for (const { attribute, mergeStrategy } of mergeableAttributes) {
+			for (const { attribute: attributeName, mergeStrategy } of mergeableAttributes) {
+				const attribute = Object.keys(receiver).find((k) => {
+					return k?.toLowerCase()?.includes(attributeName.toLowerCase());
+				});
+
 				switch (mergeStrategy) {
 					case "append": {
 						outputObject[attribute] = `${receiver[attribute] ?? ''}${merger[attribute] ?? ''}`;


### PR DESCRIPTION
Fixes issue with Paragraph block not behaving corretly with regards to enter-block-splitting, merging blocks, etc.

It now behaves exactly like the native Paragraph block! 🎉 

Also, the `mergeableAttributes` functionality should work fine with prefixed attributes now (the solution is not the greatest, but with the data we get passed to the merge function that's the best I could do).