### PR TITLE
Infinum ESLint config version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 		"@babel/polyfill": "^7.12.1",
-		"@infinumjs/eslint-config-react-js": "^2.2.0",
+		"@infinumjs/eslint-config-react-js": "^2.7.0",
 		"@wordpress/api-fetch": "^5.2.2",
 		"@wordpress/babel-preset-default": "^4.20.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",


### PR DESCRIPTION
As we had `^2.2.0` in our `package.json`, the latest version of the config wasn't being pulled, so the (very) recently added semicolon rule wasn't applying. This PR bumps the version of the config to include the newest one.