### PR TITLE
Remove example attributes. Adjust blockDetails helper

### DIFF
--- a/blocks/init/src/Blocks/variations/button-block/manifest.json
+++ b/blocks/init/src/Blocks/variations/button-block/manifest.json
@@ -6,12 +6,6 @@
 	"icon": {
 		"src": "es-button-block"
 	},
-	"example": {
-		"attributes": {
-			"buttonButtonWidth": "block",
-			"buttonButtonContent": "Button variation"
-		}
-	},
 	"attributes": {
 		"buttonButtonWidth": "block"
 	},

--- a/blocks/init/src/Blocks/variations/card-simple/manifest.json
+++ b/blocks/init/src/Blocks/variations/card-simple/manifest.json
@@ -6,14 +6,6 @@
 	"icon": {
 		"src": "es-card-simple"
 	},
-	"example": {
-		"attributes": {
-			"cardCardHeadingContent": "Test Heading",
-			"cardCardIntroContent": "Test Intro",
-			"cardCardParagraphUse": false,
-			"cardCardButtonContent": "Button Link Test"
-		}
-	},
 	"attributes": {
 		"cardCardHeadingContent": "Test Heading",
 		"cardCardIntroContent": "Test Intro",

--- a/scripts/storybook/helpers.js
+++ b/scripts/storybook/helpers.js
@@ -83,8 +83,8 @@ export const blockDetails = (blockManifest, globalManifest, isVariation = false)
 
 		output = {
 			blockName: getFullBlockNameVariation(globalManifest, blockManifest),
-			attributes: variation.example.attributes,
-			innerBlocks: getInnerBlocks(variation.example.innerBlocks),
+			attributes: variation.example?.attributes ?? variation.attributes,
+			innerBlocks: getInnerBlocks(variation.example?.innerBlocks ?? variation.innerBlocks),
 			isVariation,
 		};
 	} else {


### PR DESCRIPTION
Related to issue: #447 
Removes example key from manifest and updates blockDetails helper to fallback to attributes if example attributes are not defined

### Video

https://user-images.githubusercontent.com/23059501/140516910-6deb3652-1326-4bf2-bbfe-e6dff76ff2bb.mov


