### PR TITLE
Add icon from the parent block to block variations if no icon is supplied

### DIFF
--- a/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
@@ -31,7 +31,7 @@ registerBlocks(
 registerVariations(
 	globalSettings,
 	require.context('./../../variations', true, /manifest.json$/),
-	require.context('./../../custom', true, /manifest.json$/)
+	require.context('./../../custom', true, /manifest.json$/),
 );
 
 // Run Wrapper hooks.

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
@@ -31,6 +31,7 @@ registerBlocks(
 registerVariations(
 	globalSettings,
 	require.context('./../../variations', true, /manifest.json$/),
+	require.context('./../../custom', true, /manifest.json$/)
 );
 
 // Run Wrapper hooks.

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -483,7 +483,14 @@ const registerVariation = (
 ) => {
 
 	// Append globalManifest data in to output.
-	blockManifest['icon'] = getIconOptions(globalManifest, blockManifest);
+	if (blockManifest['icon']) {
+		blockManifest['icon'] = getIconOptions(globalManifest, blockManifest);
+	} else {
+		// There is no icon passed to variation, use it's parent icon instead
+		import(`./../../blocks/init/src/Blocks/custom/${blockManifest.parentName}/manifest.json`).then((parentManifest) => {
+			blockManifest['icon'] = getIconOptions(globalManifest, parentManifest);
+		});
+	}
 
 	// This is a full block name used in Block Editor.
 	const fullBlockName = getFullBlockNameVariation(globalManifest, blockManifest);

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -481,7 +481,7 @@ export const getExample = (
 const registerVariation = (
 	globalManifest = {},
 	blockManifest = {},
-	allBlocksManifests
+	allBlocksManifests,
 ) => {
 
 	// Append globalManifest data in to output.

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -481,7 +481,7 @@ export const getExample = (
 const registerVariation = (
 	globalManifest = {},
 	blockManifest = {},
-	allBlocksManifests,
+	allBlocksManifests = [],
 ) => {
 
 	// Append globalManifest data in to output.
@@ -697,7 +697,7 @@ export const registerVariations = (
 		const blockDetails = registerVariation(
 			globalManifest,
 			blockManifest,
-			allBlocksManifests
+			allBlocksManifests,
 		);
 
 		// Native WP method for block registration.

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -472,14 +472,16 @@ export const getExample = (
 /**
  * Map and prepare all options from block manifest.json file for usage in registerBlockVariation method.
  *
- * @param {object} globalManifest - Global manifest.
- * @param {object} blockManifest  - Block manifest.
+ * @param {object} globalManifest     - Global manifest.
+ * @param {object} blockManifest      - Block manifest.
+ * @param {Array} allBlocksManifests  - All Blocks manifests.
  *
  * @returns {object}
  */
 const registerVariation = (
 	globalManifest = {},
 	blockManifest = {},
+	allBlocksManifests
 ) => {
 
 	// Append globalManifest data in to output.
@@ -487,8 +489,10 @@ const registerVariation = (
 		blockManifest['icon'] = getIconOptions(globalManifest, blockManifest);
 	} else {
 		// There is no icon passed to variation, use it's parent icon instead
-		import(`./../../blocks/init/src/Blocks/custom/${blockManifest.parentName}/manifest.json`).then((parentManifest) => {
-			blockManifest['icon'] = getIconOptions(globalManifest, parentManifest);
+		allBlocksManifests.forEach(manifest => {
+			if (manifest.name === blockManifest.name) {
+				blockManifest['icon'] = manifest['icon'];
+			}
 		});
 	}
 
@@ -684,6 +688,7 @@ export const registerVariations = (
 	globalManifest = {},
 	blocksManifestPath,
 ) => {
+	const allBlocksManifests = blocksManifestPath.keys().map(blocksManifestPath);
 
 	// Iterate blocks to register.
 	blocksManifestPath.keys().map(blocksManifestPath).map((blockManifest) => {
@@ -691,7 +696,8 @@ export const registerVariations = (
 		// Pass data to registerVariation helper to get final output for registerBlockVariation.
 		const blockDetails = registerVariation(
 			globalManifest,
-			blockManifest
+			blockManifest,
+			allBlocksManifests
 		);
 
 		// Native WP method for block registration.


### PR DESCRIPTION
# Description

Added check if variation block has icon in it's manifest.
If it doesn't, script will import it's parent manifest and then it will set variation missing icon to parent block icon.