### PR TITLE
Fix overlapping issue

### DIFF
--- a/scripts/components/custom-select/custom-select.js
+++ b/scripts/components/custom-select/custom-select.js
@@ -7,7 +7,7 @@ import AsyncSelect from "react-select/async";
 
 /**
  * A modern, flexible and customizable select menu.
- * 
+ *
  * @param {object} props                                               - CustomSelect options.
  * @param {string?} [props.label]                                      - Label displayed above the control.
  * @param {string?} [props.help]                                       - Help text displayed below the control.
@@ -115,7 +115,7 @@ export const CustomSelect = (props) => {
 
 		let output;
 
-		// Compare current selected posts with the API and sync them. 
+		// Compare current selected posts with the API and sync them.
 		// This will remove posts that are trashed, deleted or drafted.
 		// This will change the title if the post title has changed.
 		if (multiple) {
@@ -134,6 +134,8 @@ export const CustomSelect = (props) => {
 		onChange(newValue);
 	};
 
+	const customSelectClass = 'components-custom-select';
+
 	const selectControl = (
 		<SortableSelect
 			useDragHandle
@@ -144,6 +146,7 @@ export const CustomSelect = (props) => {
 			value={(!multiple && simpleValue) ? options.filter(({ value }) => value === selected) : selected}
 			loadOptions={customLoadOptions}
 			cacheOptions={cacheOptions}
+			className={customSelectClass}
 			placeholder={placeholder}
 			defaultOptions={defaultOptions}
 			onChange={onChangeInternal}

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -509,6 +509,11 @@ body {
 		}
 	}
 
+	// Style for CustomSelect component.
+	.components-custom-select {
+		z-index: 4;
+	}
+
 	// Style for CustomSelect item with icon on the left.
 	.es-custom-select-flex {
 		display: flex;
@@ -595,7 +600,7 @@ body {
 	// Styles for making empty block placeholders visible and usable (especially in Columns).
 	.block-editor-block-list__layout {
 		height: 100%;
-	
+
 		// If it's empty.
 		&:empty {
 			height: 100%;
@@ -603,17 +608,17 @@ body {
 			border-radius: 8px;
 			border: 1px dashed hsl(0, 0%, 90%);
 		}
-	
+
 		// If it has one child, expand the expander to fill everything.
 		// (aka when empty InnerBlocks is clicked and only has the appender)
 		.block-list-appender.wp-block:only-child {
 			height: 100%;
-	
+
 			.components-dropdown.block-editor-inserter {
 				border-radius: 8px;
 				border: 1px dashed hsl(0, 0%, 90%);
 				height: 100%;
-	
+
 				.block-list-appender__toggle.block-editor-button-block-appender {
 					min-height: 4rem;
 					width: 100%;
@@ -622,7 +627,7 @@ body {
 				}
 			}
 		}
-	
+
 		// Resize the appender when it's not the only child
 		// to make it easier to hit.
 		.block-list-appender.wp-block:not(:only-child) {
@@ -632,12 +637,12 @@ body {
 			}
 		}
 	}
-	
+
 	// Resize InnerBlocks container to fit.
 	.block-editor-inner-blocks {
 		height: 100%;
 	}
-	
+
 	// Center the default [+] inserter.
 	.block-editor-inserter {
 		display: flex !important;
@@ -741,7 +746,7 @@ body {
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
-	
+
 		.components-button {
 			justify-content: flex-start !important;
 
@@ -793,11 +798,11 @@ body {
 		align-items: center;
 		grid-template-columns: 0.6rem 1fr;
 		grid-gap: 1rem;
-	
+
 		i {
 			margin: 0;
 			padding: 0;
-	
+
 			svg {
 				width: 1.2rem;
 				height: 1.2rem;


### PR DESCRIPTION
Issue: [#426](https://github.com/infinum/eightshift-frontend-libs/issues/426)

Added z-index to `CustomSelect` component to prevent overlapping with other components.

<img width="272" alt="frontend-libs-ovelapping-1" src="https://user-images.githubusercontent.com/19992824/140785466-28afa76e-06c0-4677-a8f4-d4638bff7f71.png">

<img width="272" alt="frontend-libs-overlapping-2" src="https://user-images.githubusercontent.com/19992824/140785488-0b7430d5-7a98-416a-9989-9d46c56648e4.png">
