### PR TITLE
Fix for #489: Buttons have an aria-label attribute, but no editor for it

### DIFF
--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -56,7 +56,7 @@ $buttonClass = Components::classnames([
 		class="<?php echo \esc_attr($buttonClass); ?>"
 		id="<?php echo \esc_attr($buttonId); ?>"
 		title="<?php echo \esc_attr($buttonContent); ?>"
-		<?php if(!empty($buttonAriaLabel)) { ?>
+		<?php if (!empty($buttonAriaLabel)) { ?>
 			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
 		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"
@@ -75,7 +75,7 @@ $buttonClass = Components::classnames([
 		class="<?php echo \esc_attr($buttonClass); ?>"
 		id="<?php echo \esc_attr($buttonId); ?>"
 		title="<?php echo \esc_attr($buttonContent); ?>"
-		<?php if(!empty($buttonAriaLabel)) { ?>
+		<?php if (!empty($buttonAriaLabel)) { ?>
 			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
 		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -56,7 +56,9 @@ $buttonClass = Components::classnames([
 		class="<?php echo \esc_attr($buttonClass); ?>"
 		id="<?php echo \esc_attr($buttonId); ?>"
 		title="<?php echo \esc_attr($buttonContent); ?>"
-		aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+		<?php if(!empty($buttonAriaLabel)) { ?>
+			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"
 		<?php
 		foreach ($buttonAttrs as $key => $value) {
@@ -73,7 +75,9 @@ $buttonClass = Components::classnames([
 		class="<?php echo \esc_attr($buttonClass); ?>"
 		id="<?php echo \esc_attr($buttonId); ?>"
 		title="<?php echo \esc_attr($buttonContent); ?>"
-		aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+		<?php if(!empty($buttonAriaLabel)) { ?>
+			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"
 		<?php
 		foreach ($buttonAttrs as $key => $value) {

--- a/blocks/init/src/Blocks/components/button/components/button-options.js
+++ b/blocks/init/src/Blocks/components/button/components/button-options.js
@@ -105,7 +105,7 @@ export const ButtonOptions = (attributes) => {
 				
 					{showButtonAriaLabel &&
 						<TextControl
-					label={<IconLabel icon={icons.infoCircle} label={__('ARIA label', 'eightshift-frontend-libs')} />}
+							label={<IconLabel icon={icons.infoCircle} label={__('ARIA label', 'eightshift-frontend-libs')} />}
 							value={buttonAriaLabel}
 							onChange={(value) => setAttributes({ [getAttrKey('buttonAriaLabel', attributes, manifest)]: value })}
 						/>

--- a/blocks/init/src/Blocks/components/button/components/button-options.js
+++ b/blocks/init/src/Blocks/components/button/components/button-options.js
@@ -16,6 +16,7 @@ export const ButtonOptions = (attributes) => {
 
 		showButtonUse = false,
 		showLabel = false,
+		showButtonAriaLabel = true,
 		showButtonColor = true,
 		showButtonSize = true,
 		showButtonWidth = true,
@@ -35,6 +36,7 @@ export const ButtonOptions = (attributes) => {
 	const buttonIsAnchor = checkAttr('buttonIsAnchor', attributes, manifest);
 	const buttonId = checkAttr('buttonId', attributes, manifest);
 	const buttonIsLink = checkAttr('buttonIsLink', attributes, manifest);
+	const buttonAriaLabel = checkAttr('buttonAriaLabel', attributes, manifest);
 
 	const sizeOptions = getOption('buttonSize', attributes, manifest).map(({ label, value, icon: iconName }) => {
 		return {
@@ -100,7 +102,15 @@ export const ButtonOptions = (attributes) => {
 							options={widthOptions}
 						/>
 					}
-
+				
+					{showButtonAriaLabel &&
+						<TextControl
+					label={<IconLabel icon={icons.infoCircle} label={__('ARIA label', 'eightshift-frontend-libs')} />}
+							value={buttonAriaLabel}
+							onChange={(value) => setAttributes({ [getAttrKey('buttonAriaLabel', attributes, manifest)]: value })}
+						/>
+					}
+				
 					{showButtonIsAnchor &&
 						<IconToggle
 							icon={icons.anchor}


### PR DESCRIPTION
This PR should fix #489. It adds a `TextControl` for the `buttonAriaLabel` attribute to `button-options.js` and changes `button.php` so that we only output the `aria-label` attribute if it's not empty.