### PR TITLE
CollapsableComponentUseToggle fix and tweak

### DIFF
--- a/scripts/components/collapsable-component-use-toggle/collapsable-component-use-toggle.js
+++ b/scripts/components/collapsable-component-use-toggle/collapsable-component-use-toggle.js
@@ -35,6 +35,10 @@ export const CollapsableComponentUseToggle = ({
 		areChildrenExpanded ? 'is-open' : '',
 	]);
 
+	if (!showLabel && !showUseToggle) {
+		return children;
+	}
+
 	return (
 		<BaseControl className={componentClasses}>
 			<div className='es-collapsable-component-use-toggle__trigger'>

--- a/scripts/components/index.js
+++ b/scripts/components/index.js
@@ -10,6 +10,7 @@ export {
 	ColorPickerComponent,
 	ColorPickerType
 } from './color-picker-component/color-picker-component';
+export { CollapsableComponentUseToggle } from './collapsable-component-use-toggle/collapsable-component-use-toggle';
 export { ComponentUseToggle } from './component-use-toggle/component-use-toggle';
 export { CustomSelect } from './custom-select/custom-select';
 export { HeadingLevel } from './heading-level/heading-level';


### PR DESCRIPTION
This PR adds the missing export for the component 😅  and spits out content only when `showLabel` and `showUseToggle` are both `false`, allowing for more flexibility.