### PR TITLE
Lists component improvements

### DIFF
--- a/blocks/init/src/Blocks/components/lists/components/lists-editor.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-editor.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import { outputCssVariables, getUnique, selector, checkAttr, getAttrKey } from '@eightshift/frontend-libs/scripts';
+import { outputCssVariables, getUnique, selector, checkAttr, getAttrKey, getOption } from '@eightshift/frontend-libs/scripts';
 import manifest from './../manifest.json';
 import globalManifest from './../../../manifest.json';
 
@@ -24,6 +24,12 @@ export const ListsEditor = (attributes) => {
 	const listsUse = checkAttr('listsUse', attributes, manifest);
 	const listsContent = checkAttr('listsContent', attributes, manifest);
 	const listsOrdered = checkAttr('listsOrdered', attributes, manifest);
+
+	const listsOrderedOptions = getOption('listsOrdered', attributes, manifest).map(option => option.value);
+	const listsDefault = manifest.attributes.listsOrdered.default;
+	if (!listsOrderedOptions.includes(listsOrdered)) {
+		setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: listsDefault }); // Resets the attribute to the default value if invalid value set.
+	}
 
 	const listsClass = classnames([
 		selector(componentClass, componentClass),

--- a/blocks/init/src/Blocks/components/lists/components/lists-options.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-options.js
@@ -18,6 +18,7 @@ export const ListsOptions = (attributes) => {
 		showListsColor = true,
 		showListsSize = true,
 		showListsColorOnlyMarker = true,
+		showListsOrdered = true,
 	} = attributes;
 
 	if (!listsShowControls) {
@@ -28,6 +29,7 @@ export const ListsOptions = (attributes) => {
 	const listsColor = checkAttr('listsColor', attributes, manifest);
 	const listsSize = checkAttr('listsSize', attributes, manifest);
 	const listsColorOnlyMarker = checkAttr('listsColorOnlyMarker', attributes, manifest);
+	const listsOrdered = checkAttr('listsOrdered', attributes, manifest);
 
 	return (
 		<>
@@ -62,6 +64,18 @@ export const ListsOptions = (attributes) => {
 						/>
 					}
 
+					{showListsOrdered &&
+						<CustomSelect
+							label={<IconLabel icon={<BlockIcon iconName='es-footnotes' />} label={__('List type', 'edp')} />}
+							value={listsOrdered}
+							options={getOption('listsOrdered', attributes, manifest)}
+							onChange={(value) => setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: value })}
+							isClearable={false}
+							isSearchable={false}
+							simpleValue
+						/>
+					}
+				
 					{showListsColorOnlyMarker &&
 						<IconToggle
 							icon={<BlockIcon iconName='es-list-item' />}

--- a/blocks/init/src/Blocks/components/lists/components/lists-options.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-options.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { ColorPaletteCustom, icons, getOption, checkAttr, getAttrKey, ComponentUseToggle, IconLabel, CustomSelect, IconToggle, BlockIcon } from '@eightshift/frontend-libs/scripts';
+import { ColorPaletteCustom, icons, getOption, checkAttr, getAttrKey, ComponentUseToggle, IconLabel, CustomSelect, IconToggle, BlockIcon, SimpleVerticalSingleSelect } from '@eightshift/frontend-libs/scripts';
 import manifest from '../manifest.json';
 
 export const ListsOptions = (attributes) => {
@@ -65,8 +65,8 @@ export const ListsOptions = (attributes) => {
 					}
 
 					{showListsOrdered &&
-						<CustomSelect
-							label={<IconLabel icon={<BlockIcon iconName='es-footnotes' />} label={__('List type', 'eightshift-frontend-libs')} />}
+						<SimpleVerticalSingleSelect
+							label={__('List type', 'edp')}
 							value={listsOrdered}
 							options={getOption('listsOrdered', attributes, manifest)}
 							onChange={(value) => setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: value })}

--- a/blocks/init/src/Blocks/components/lists/components/lists-options.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-options.js
@@ -66,7 +66,7 @@ export const ListsOptions = (attributes) => {
 
 					{showListsOrdered &&
 						<SimpleVerticalSingleSelect
-							label={__('List type', 'edp')}
+							label={__('List type', 'eightshift-frontend-libs')}
 							value={listsOrdered}
 							options={getOption('listsOrdered', attributes, manifest)}
 							onChange={(value) => setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: value })}

--- a/blocks/init/src/Blocks/components/lists/components/lists-options.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-options.js
@@ -66,7 +66,7 @@ export const ListsOptions = (attributes) => {
 
 					{showListsOrdered &&
 						<CustomSelect
-							label={<IconLabel icon={<BlockIcon iconName='es-footnotes' />} label={__('List type', 'edp')} />}
+							label={<IconLabel icon={<BlockIcon iconName='es-footnotes' />} label={__('List type', 'eightshift-frontend-libs')} />}
 							value={listsOrdered}
 							options={getOption('listsOrdered', attributes, manifest)}
 							onChange={(value) => setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: value })}

--- a/blocks/init/src/Blocks/components/lists/lists.php
+++ b/blocks/init/src/Blocks/components/lists/lists.php
@@ -26,6 +26,14 @@ $selectorClass = $attributes['selectorClass'] ?? $componentClass;
 $listsContent = Components::checkAttr('listsContent', $attributes, $manifest);
 $listsOrdered = Components::checkAttr('listsOrdered', $attributes, $manifest);
 
+$listsOrderedOptions = array_map(function ($option) {
+	return $option['value'];
+}, $manifest['options']['listsOrdered'] ?? []);
+
+if (!in_array($listsOrdered, $listsOrderedOptions)) {
+	return;
+}
+
 $listsClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),

--- a/blocks/init/src/Blocks/components/lists/lists.php
+++ b/blocks/init/src/Blocks/components/lists/lists.php
@@ -30,7 +30,7 @@ $listsOrderedOptions = array_map(function ($option) {
 	return $option['value'];
 }, $manifest['options']['listsOrdered'] ?? []);
 
-if (!in_array($listsOrdered, $listsOrderedOptions)) {
+if (!in_array($listsOrdered, $listsOrderedOptions, true)) {
 	return;
 }
 

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -45,7 +45,7 @@
 				"icon": "listOrdered"
 			},
 			{
-				"label": "Bulleted list",
+				"label": "Bulleted",
 				"value": "ul",
 				"icon": "listUnordered"
 			}

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -41,11 +41,13 @@
 		"listsOrdered": [
 			{
 				"label": "Ordered list",
-				"value": "ol"
+				"value": "ol",
+				"icon": "listOrdered"
 			},
 			{
 				"label": "Bullet list",
-				"value": "ul"
+				"value": "ul",
+				"icon": "listUnordered"
 			}
 		],
 		"listsSize": [

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -40,7 +40,7 @@
 	"options": {
 		"listsOrdered": [
 			{
-				"label": "Ordered list",
+				"label": "Ordered",
 				"value": "ol",
 				"icon": "listOrdered"
 			},

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -38,6 +38,16 @@
 		}
 	},
 	"options": {
+		"listsOrdered": [
+			{
+				"label": "Ordered list",
+				"value": "ol"
+			},
+			{
+				"label": "Bullet list",
+				"value": "ul"
+			}
+		],
 		"listsSize": [
 			{
 				"label": "Default (16)",


### PR DESCRIPTION
This PR:
* implements a way to change the value of the `listsOrdered` attribute from the editor
* implements additional checks that the `listsOrdered` attribute can be only `ul` or `ol`
  * alternatively, we could make the `listsOrdered` attribute a boolean, but I decided for this approach to not break backwards compatibility - let me know if you think we should have a different approach