### PR TITLE
CustomSelect overlap fixes and fetchWpApi fix

### DIFF
--- a/scripts/components/custom-select/custom-select.js
+++ b/scripts/components/custom-select/custom-select.js
@@ -229,6 +229,40 @@ export const CustomSelect = (props) => {
 					primary: 'hsla(0, 0%, 0%, 1)'
 				},
 			})}
+			styles={{
+				menu: (provided) => {
+					let bgColor = provided?.backgroundColor ?? 'rgba(255 255 255 / 0.75)';
+
+					if (bgColor.includes('hsl') && !bgColor.includes('hsla')) {
+						bgColor = bgColor.replaceAll(',', '').replace(')', ' / 0.75)');
+					}
+
+					return {
+						...provided,
+						borderTopLeftRadius: '0',
+						borderTopRightRadius: '0',
+						zIndex: 5,
+						marginTop: 1,
+						backgroundColor: bgColor,
+						backdropFilter: 'blur(1rem) saturate(150%)',
+					};
+				},
+				control: (provided, state) => ({
+					...provided,
+					position: 'static',
+					borderBottomLeftRadius: state.menuIsOpen ? 0 : state.theme.borderRadius,
+					borderBottomRightRadius: state.menuIsOpen ? 0 : state.theme.borderRadius,
+					zIndex: state.menuIsOpen ? 4 : null,
+				}),
+				option: (provided, state) => ({
+					...provided,
+					margin: '0.125rem 0.375rem',
+					width: 'calc(100% - 0.75rem)',
+					borderRadius: '0.25rem',
+					transition: 'all 0.3s ease-out',
+					...(state.isSelected ? { backgroundColor: 'var(--wp-admin-theme-color, #111111)' } : {}),
+				}),
+			}}
 		/>
 	);
 

--- a/scripts/editor/fetch-wp-api.js
+++ b/scripts/editor/fetch-wp-api.js
@@ -46,18 +46,18 @@ export function getFetchWpApi(endpoint, options = {}) {
 	 *
 	 * @returns Array of items in { label: '', value: '' } format.
 	 */
-	const fetchItems = async (searchText) => {
+	const fetchItems = async (searchText = '') => {
 		let params = {
 			per_page: perPage,
 		};
 
 		// Add fields in the params for optimisations.
-		if (fields.length) {
+		if (fields?.length) {
 			params['_fields'] = fields;
 		}
 
 		// Merge additional params to props.
-		if (additionalParam.length) {
+		if (additionalParam?.length) {
 			params = {
 				...params,
 				...additionalParam
@@ -65,7 +65,7 @@ export function getFetchWpApi(endpoint, options = {}) {
 		}
 
 		// Fetch fresh if you are searching something.
-		if (searchText.length) {
+		if (searchText?.length) {
 			params['search'] = searchText;
 
 			const newData = await apiFetch({ path: getRoute(endpoint, params, routePrefix) });

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -509,11 +509,6 @@ body {
 		}
 	}
 
-	// Style for CustomSelect component.
-	.components-custom-select {
-		z-index: 4;
-	}
-
 	// Style for CustomSelect item with icon on the left.
 	.es-custom-select-flex {
 		display: flex;
@@ -820,7 +815,6 @@ body {
 			svg {
 				width: 1.2rem;
 				height: 1.2rem;
-				transform: translateY(2px);
 			}
 		}
 


### PR DESCRIPTION
Changes:
- fixed menu item overlap issue (closes #509)
- fixed issue with `getFetchWpApi` if called standalone
- tweaked menu design so it's connected to the select menu itself and has a bit of the content below peeking through (makes it easier to see if multiple elements are around)

After:
![image](https://user-images.githubusercontent.com/77000136/144047232-74397e7d-746e-43cb-a32f-82a9315f4e58.png)

Before:
![image](https://user-images.githubusercontent.com/77000136/144047345-0809928b-8c1c-460a-9881-b008008022a4.png)
