### PR TITLE
A11y improvements: Part 1

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -47,18 +47,20 @@ $accordionPanelClass = Components::classnames([
 ]);
 
 $accordionContentClass = Components::selector($componentClass, $componentClass, 'content');
+
+$uniqueAccordionId = Components::getUnique();
 ?>
 
 <div
 	class="<?php echo \esc_attr($accordionClass); ?>"
 	data-accordion-open="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
 	data-close-others="<?php echo \esc_attr($accordionCloseOthers ? 'true' : 'false'); ?>"
-	aria-expanded="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
 >
 	<button
 		class="<?php echo \esc_attr($accordionTriggerClass); ?>"
 		aria-label="<?php echo esc_html($accordionTitle); ?>"
-		aria-controls
+		aria-controls="<?php echo \esc_attr($uniqueAccordionId); ?>"
+		aria-expanded="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
 	>
 		<?php echo \esc_html($accordionTitle); ?>
 		<div class="<?php echo \esc_attr($accordionIconClass); ?>" aria-hidden="true" >
@@ -66,9 +68,11 @@ $accordionContentClass = Components::selector($componentClass, $componentClass, 
 		</div>
 	</button>
 
-	<section
+	<div
+		role="region"
 		class="<?php echo \esc_attr($accordionPanelClass); ?>"
 		aria-hidden="<?php echo \esc_attr($accordionIsOpen ? 'false' : 'true'); ?>"
+		id="<?php echo esc_attr($uniqueAccordionId); ?>"
 	>
 		<div class="<?php echo \esc_attr($accordionContentClass); ?>">
 			<?php
@@ -76,5 +80,5 @@ $accordionContentClass = Components::selector($componentClass, $componentClass, 
 				echo $accordionContent;
 			?>
 		</div>
-	</section>
+	</div>
 </div>

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -54,7 +54,9 @@ $buttonClass = Components::classnames([
 <?php if (! $buttonUrl) { ?>
 	<button
 		class="<?php echo \esc_attr($buttonClass); ?>"
-		id="<?php echo \esc_attr($buttonId); ?>"
+		<?php if (!empty($buttonId)) { ?>
+			id="<?php echo \esc_attr($buttonId); ?>"
+		<?php } ?>
 		title="<?php echo \esc_attr($buttonContent); ?>"
 		<?php if (!empty($buttonAriaLabel)) { ?>
 			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
@@ -73,7 +75,9 @@ $buttonClass = Components::classnames([
 	<a
 		href="<?php echo \esc_url($buttonUrl); ?>"
 		class="<?php echo \esc_attr($buttonClass); ?>"
-		id="<?php echo \esc_attr($buttonId); ?>"
+		<?php if (!empty($buttonId)) { ?>
+			id="<?php echo \esc_attr($buttonId); ?>"
+		<?php } ?>
 		title="<?php echo \esc_attr($buttonContent); ?>"
 		<?php if (!empty($buttonAriaLabel)) { ?>
 			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"

--- a/blocks/init/src/Blocks/components/head/head.php
+++ b/blocks/init/src/Blocks/components/head/head.php
@@ -37,12 +37,20 @@ $headName = Components::checkAttr('headName', $attributes, $manifest);
 <link rel="dns-prefetch" href="//www.google-analytics.com">
 
 <!-- Win phone Meta -->
-<meta name="application-name" content="<?php echo \esc_attr($headName); ?>"/>
+<?php if (isset($headName)) { ?>
+  <meta name="application-name" content="<?php echo \esc_attr($headName); ?>" />
+<?php } ?>
 
 <!-- Apple -->
-<meta name="apple-mobile-web-app-title" content="<?php echo \esc_attr($headName); ?>">
+<?php if (isset($headName)) { ?>
+  <meta name="apple-mobile-web-app-title" content="<?php echo \esc_attr($headName); ?>">
+<?php } ?>
+
 <meta name="apple-mobile-web-app-capable" content="yes">
-<link rel="apple-touch-startup-image" href="<?php echo \esc_url($headFavicon); ?>">
+
+<?php if (isset($headFavicon)) { ?>
+  <link rel="apple-touch-startup-image" href="<?php echo \esc_url($headFavicon); ?>">
+<?php } ?>
 
 <!-- General -->
 <link rel="shortcut icon" href="<?php echo \esc_url($headFavicon); ?>" />

--- a/blocks/init/src/Blocks/components/head/head.php
+++ b/blocks/init/src/Blocks/components/head/head.php
@@ -17,16 +17,15 @@ $headName = Components::checkAttr('headName', $attributes, $manifest);
 
 ?>
 
-<meta charset="<?php echo \esc_attr($headCharset); ?>" />
+<?php if (isset($headCharset)) { ?>
+  <meta charset="<?php echo \esc_attr($headCharset); ?>" />
+<?php } ?>
 
 <!-- Responsive -->
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
 <!-- Remove IE's ability to use compatibility mode -->
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
-<!-- Correct type -->
-<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 
 <!-- Disable phone formatting on safari -->
 <meta name="format-detection" content="telephone=no">

--- a/blocks/init/src/Blocks/components/head/manifest.json
+++ b/blocks/init/src/Blocks/components/head/manifest.json
@@ -6,7 +6,8 @@
 			"type": "string"
 		},
 		"headCharset": {
-			"type": "string"
+			"type": "string",
+			"default": "utf-8"
 		},
 		"headName": {
 			"type": "string"

--- a/blocks/init/src/Blocks/components/image/image.php
+++ b/blocks/init/src/Blocks/components/image/image.php
@@ -40,7 +40,7 @@ $imgClass = Components::classnames([
 ?>
 
 <?php if (isset($imageUrl['large']) && $imageUrl['large']) { ?>
-	<picture class="<?php echo \esc_attr($pictureClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+	<picture class="<?php echo \esc_attr($pictureClass); ?>" data-id="<?php echo esc_attr($unique); ?>" alt="<?php echo esc_attr($imageAlt); ?>">
 
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -66,6 +66,6 @@ $imgClass = Components::classnames([
 			?>
 		<?php } ?>
 
-		<img src="<?php echo \esc_url($imageUrl['large']); ?>" alt="<?php echo \esc_attr($imageAlt); ?>" class="<?php echo \esc_attr($imgClass); ?>" />
+		<img src="<?php echo \esc_url($imageUrl['large']); ?>" class="<?php echo \esc_attr($imgClass); ?>" alt="<?php echo esc_attr($imageAlt); ?>" />
 	</picture>
 <?php } ?>

--- a/blocks/init/src/Blocks/components/image/image.php
+++ b/blocks/init/src/Blocks/components/image/image.php
@@ -11,7 +11,7 @@ use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 $globalManifest = Components::getManifest(dirname(__DIR__, 2));
 $manifest = Components::getManifest(__DIR__);
 
-$imageUse = Components::checkAttr('imageUse', $attributes, $manifest);
+$imageUse = Components::checkAttr('imageUse', $attributes, $manifest) ?? false;
 if (!$imageUse) {
 	return;
 }

--- a/blocks/init/src/Blocks/components/modal/modal.php
+++ b/blocks/init/src/Blocks/components/modal/modal.php
@@ -39,7 +39,9 @@ $modalClass = Components::classnames([
 
 <div
 	class="<?php echo \esc_attr($modalClass); ?>"
-	id="<?php echo \esc_attr($modalId); ?>"
+	<?php if (!empty($modalId)) { ?>
+		id="<?php echo \esc_attr($modalId); ?>"
+	<?php } ?>
 	aria-hidden="true"
 >
 	<div

--- a/blocks/init/src/Blocks/components/search-bar/search-bar.php
+++ b/blocks/init/src/Blocks/components/search-bar/search-bar.php
@@ -60,7 +60,9 @@ $labelClass = Components::classnames([
 		type="text"
 		value="<?php echo \get_search_query(); ?>"
 		name="s"
-		id="<?php echo \esc_attr($searchBarId); ?>"
+		<?php if (!empty($searchBarId)) { ?>
+			id="<?php echo \esc_attr($searchBarId); ?>"
+		<?php } ?>
 		class="<?php echo \esc_attr($inputClass); ?>"
 		placeholder="<?php echo \esc_attr($searchBarPlaceholder); ?>"
 	/>


### PR DESCRIPTION
Decided to split this into two PRs, so it doesn't become too big. 😅 

Fixes these issues reported in #491:

- [x] ID's are sometimes empty, as in `id=""`: "Bad value for attribute id on element a: An ID must not be the empty string."
 - [x] `<meta charset="" />` is output if a charset isn't set in the manifest (we should probably provide a default for that)
 - [x]  "A document must not include both a meta element with an http-equiv attribute whose value is content-type, and a meta element with a charset attribute."
 - [x]  If the `headFavicon` attribute isn't set, we output `<link rel="apple-touch-startup-image" href="">`, which is an invalid value
 - [x] The `accordion` component uses the `aria-expanded` attribute, but doesn't have an ARIA role: "The ARIA attribute 'aria-expanded' is not valid for the element <div> with ARIA role 'none'" (please see detailed commit message for this)
 