### PR TITLE
Block attribute deprecation/migration

### DIFF
--- a/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks-editor.js
@@ -26,6 +26,7 @@ registerBlocks(
 	require.context('./../../custom', true, /-block.js$/),
 	require.context('./../../custom', true, /-hooks.js$/),
 	require.context('./../../custom', true, /-transforms.js$/),
+	require.context('./../../custom', true, /-deprecations.js$/),
 );
 
 registerVariations(


### PR DESCRIPTION
Adds support for deprecating and migrating block attributes, based on https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/.

Closes #291 .

### Preliminary documentation
(will be added to Docs soon)

It supports 2 ways of doing this, both should happen in `blockName-deprecations.js` (same level as `blockName-style.scss`, `blockName-block.js`, ...)

**The easy (and preferred) way is to have:**
```js
export const deprecated = [
	{
		oldAttributes: {
			prevNextNavButtonsPrevUrl: {
				type: "string"
			},
			prevNextNavButtonsNextUrl: {
				type: "string"
			},
		},
		newAttributes: ({ prevNextNavButtonsPrevUrl, prevNextNavButtonsNextUrl }) => ({
			prevNextNavButtonsPrevUrl2: prevNextNavButtonsPrevUrl,
			prevNextNavButtonsNextUrl2: prevNextNavButtonsNextUrl,
		}),
	},
];
```
in the file.

`oldAttributes` are the old versions of the manifest attributes you want to migrate.
`newAttributes` is the function that returns all the new attributes that need to be added (you should be able to set an existing attribute to `undefined` to remove it).

Optionally, you can pass `isEligible: (attributes) => { ... }`, which should return `true` or `false` to signify if that migration should be run.

**The more manual way** would be to add all the attributes that WordPress documentantion mentions:
- `attributes` - array of manifest attributes
- `migrate` - function(object) that specifies attribute migration
- `isEligible` - function(bool) that signifies if the migration should be run

Please note that with the _manual_ way, you need to pass all the attributes yourself (to the `attributes` and the return object of `migrate`) using `getAttributes` from Frontend Libs, otherwise you may encounter broken blocks!

```js
export const deprecated = [
	{
		attributes: {
			...getAttributes(globalManifest, wrapperManifest, componentsManifests, manifest),
			prevNextNavButtonsLeftUrl: {
				type: "string"
			},
			prevNextNavButtonsRightUrl: {
				type: "string"
			},
		},

		migrate: (attributes) => {
			const { prevNextNavButtonsPrevUrl, prevNextNavButtonsNextUrl } = attributes;

			return {
				...getAttributes(globalManifest, wrapperManifest, componentsManifests, manifest),
				...attributes,
				prevNextNavButtonsPrevUrl: prevNextNavButtonsLeftUrl,
				prevNextNavButtonsNextUrl: prevNextNavButtonsRightUrl,
			};
		},
	}
];

```