### PR TITLE
Fix #419

### DIFF
--- a/setup/create-wp-project/src/basics/argument-operations.js
+++ b/setup/create-wp-project/src/basics/argument-operations.js
@@ -46,7 +46,7 @@ const maybePrompt = async(scriptArguments, argv) => {
         // on their settings.
         if (argument.skipPrompt) {
           continue;
-        } else if (argument.buildFrom) {
+        } else if (typeof(argv[argName]) === "undefined" && argument.buildFrom) {
           const { how, name } = argument.buildFrom;
           answers = { ...answers, [argument.name]: how(answers[name]) };
         } else {

--- a/setup/create-wp-project/src/basics/argument-operations.js
+++ b/setup/create-wp-project/src/basics/argument-operations.js
@@ -33,7 +33,8 @@ const summary = async(answers) => {
 const maybePrompt = async(scriptArguments, argv) => {
   let answers = {};
   let confirm = false;
-
+  let prompted = false;
+  
   do {
     for (const argName in scriptArguments) {
       if (Object.prototype.hasOwnProperty.call(scriptArguments, argName)) {
@@ -53,6 +54,11 @@ const maybePrompt = async(scriptArguments, argv) => {
 
           // If argument is provided from CLI use that, otherwise prompt.
           const answer = argv[argName] ? { [argName]: argv[argName] } : await inquirer.prompt(argument);
+
+          if (typeof (argv[argName]) === "undefined") {
+            prompted = true;
+          }
+
           answers = { ...answers, ...answer };
         }
       }
@@ -61,6 +67,11 @@ const maybePrompt = async(scriptArguments, argv) => {
     // Skip summary if noSummary argument is provided
     if (!argv.noSummary) {
       confirm = await summary(answers);
+
+      if (!confirm && prompted === false) {
+        process.exit(0);
+      }
+
       log('');
     } else {
       confirm = true;


### PR DESCRIPTION
Fixes #419 by:
* running `buildFrom` only if argument is not set via `argv`
* exiting the script if the user says it doesn't look good, and we haven't prompted for arguments (that is, all arguments have been passed via `argv` or set using `buildFrom`)
   * perhaps we could prompt for all arguments in that case?