### PR TITLE
Fix/set correct installation dir path

### DIFF
--- a/setup/create-wp-project/src/basics/files.js
+++ b/setup/create-wp-project/src/basics/files.js
@@ -2,7 +2,25 @@ const replace = require('replace-in-file');
 const path = require('path');
 const { readdir, rename } = require('fs-extra');
 
-const fullPath = path.join(process.cwd());
+/**
+ * Checks and returns required directory path.
+ *
+ * @param {string} requiredFolder Folder where installation must occur.
+ */
+const fullPath = async (requiredFolder = 'themes') => {
+  const currentPath = path.join(process.cwd());
+  const currentDirName = path.basename(currentPath);
+
+  if (currentDirName === requiredFolder) {
+    return currentPath;
+  }
+
+  const themesPath = (currentDirName === 'wp-content') ?
+    `${currentPath}/${requiredFolder}` :
+    `${currentPath}/wp-content/${requiredFolder}`;
+
+  return themesPath;
+};
 
 /**
  * Performs a wide search & replace.

--- a/setup/create-wp-project/src/basics/files.js
+++ b/setup/create-wp-project/src/basics/files.js
@@ -2,12 +2,14 @@ const replace = require('replace-in-file');
 const path = require('path');
 const { readdir, rename } = require('fs-extra');
 
+const fullPath = path.join(process.cwd());
+
 /**
  * Checks and returns required directory path.
  *
  * @param {string} requiredFolder Folder where installation must occur.
  */
-const fullPath = async (requiredFolder = 'themes') => {
+const installPath = async (requiredFolder = 'themes') => {
   const currentPath = path.join(process.cwd());
   const currentDirName = path.basename(currentPath);
 
@@ -69,6 +71,7 @@ const readdirAsync = async (dirPath) => new Promise((resolve, reject) => {
 module.exports = {
   fullPath,
   findReplace,
+  installPath,
   readdirAsync,
   rename,
 };

--- a/setup/create-wp-project/src/basics/files.js
+++ b/setup/create-wp-project/src/basics/files.js
@@ -15,11 +15,11 @@ const fullPath = async (requiredFolder = 'themes') => {
     return currentPath;
   }
 
-  const themesPath = (currentDirName === 'wp-content') ?
+  const requiredPath = (currentDirName === 'wp-content') ?
     `${currentPath}/${requiredFolder}` :
     `${currentPath}/wp-content/${requiredFolder}`;
 
-  return themesPath;
+  return requiredPath;
 };
 
 /**

--- a/setup/create-wp-project/src/commands/plugin.js
+++ b/setup/create-wp-project/src/commands/plugin.js
@@ -33,7 +33,8 @@ exports.handler = async (argv) => {
   let step = 1;
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
-  const projectPath = path.join(fullPath, promptedInfo.package);
+  const requiredPath = await fullPath('plugins');
+  const projectPath = path.join(requiredPath, promptedInfo.package);
   log('');
 
   await installStep({

--- a/setup/create-wp-project/src/commands/plugin.js
+++ b/setup/create-wp-project/src/commands/plugin.js
@@ -15,7 +15,7 @@ const {
     installNodeDependencies,
     installComposerDependencies,
   },
-  files: { fullPath },
+  files: { installPath },
   misc: { log, variable },
 } = require('../basics');
 const { searchReplace } = require('../search-replace');
@@ -33,7 +33,7 @@ exports.handler = async (argv) => {
   let step = 1;
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
-  const requiredPath = await fullPath('plugins');
+  const requiredPath = await installPath('plugins');
   const projectPath = path.join(requiredPath, promptedInfo.package);
   log('');
 

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -31,7 +31,8 @@ exports.handler = async (argv) => {
   let step = 1;
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
-  const projectPath = path.join(fullPath, promptedInfo.package);
+  const requiredPath = await fullPath('themes');
+  const projectPath = path.join(requiredPath, promptedInfo.package);
   const boilerplateRepoUrl = argv.eightshiftBoilerplateRepo ?? 'https://github.com/infinum/eightshift-boilerplate.git';
   const boilerplateRepoBranch = argv.eightshiftBoilerplateBranch ?? '';
 

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -13,7 +13,7 @@ const {
     installNodeDependencies,
     installComposerDependencies,
   },
-  files: { fullPath },
+  files: { installPath },
   misc: { log, variable },
 } = require('../basics');
 const { searchReplace } = require('../search-replace');
@@ -31,7 +31,7 @@ exports.handler = async (argv) => {
   let step = 1;
 
   const promptedInfo = await maybePrompt(scriptArguments, argv);
-  const requiredPath = await fullPath('themes');
+  const requiredPath = await installPath('themes');
   const projectPath = path.join(requiredPath, promptedInfo.package);
   const boilerplateRepoUrl = argv.eightshiftBoilerplateRepo ?? 'https://github.com/infinum/eightshift-boilerplate.git';
   const boilerplateRepoBranch = argv.eightshiftBoilerplateBranch ?? '';


### PR DESCRIPTION
# Description

If located in WP `root` folder or `wp-content` folder during installation, this forces installation in `themes/plugins` folders. They will be created additionally if they don't exist.

Related issue: [#498](https://github.com/infinum/eightshift-frontend-libs/issues/498)