### PR TITLE
Component improvements

### DIFF
--- a/blocks/init/assets/scripts/application.js
+++ b/blocks/init/assets/scripts/application.js
@@ -5,5 +5,5 @@
  */
 
 if (!window?._babelPolyfill) {
-	require('@babel/polyfill');
+	require('@babel/polyfill'); // eslint-disable-line no-underscore-dangle
 }

--- a/blocks/init/assets/scripts/application.js
+++ b/blocks/init/assets/scripts/application.js
@@ -4,6 +4,6 @@
  * Usage: `WordPress frontend screen`.
  */
 
-if (!window?._babelPolyfill) {
-	require('@babel/polyfill'); // eslint-disable-line no-underscore-dangle
+if (!window?._babelPolyfill) { // eslint-disable-line no-underscore-dangle
+	require('@babel/polyfill');
 }

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks.js
@@ -10,7 +10,7 @@
 import { dynamicImport } from '@eightshift/frontend-libs/scripts/helpers';
 
 if (!window?._babelPolyfill) {
-	require('@babel/polyfill');
+	require('@babel/polyfill'); // eslint-disable-line no-underscore-dangle
 }
 
 // Find all blocks and require assets index.js inside it.

--- a/blocks/init/src/Blocks/assets/scripts/application-blocks.js
+++ b/blocks/init/src/Blocks/assets/scripts/application-blocks.js
@@ -9,8 +9,8 @@
  */
 import { dynamicImport } from '@eightshift/frontend-libs/scripts/helpers';
 
-if (!window?._babelPolyfill) {
-	require('@babel/polyfill'); // eslint-disable-line no-underscore-dangle
+if (!window?._babelPolyfill) { // eslint-disable-line no-underscore-dangle
+	require('@babel/polyfill');
 }
 
 // Find all blocks and require assets index.js inside it.

--- a/scripts/components/advanced-color-picker/advanced-color-picker.js
+++ b/scripts/components/advanced-color-picker/advanced-color-picker.js
@@ -53,6 +53,7 @@ const CustomValueDisplay = (props) => {
  * @param {Array} [props.types]             - Types of choices to show. The array should have objects in `{label: '', value: ''}` format. Defaults provide 'nothing', 'solid color', 'project color' and 'gradient' options.
  * @param {string?} [props.label]           - Label displayed above the control.
  * @param {string?} [props.help]            - Help text displayed below the control.
+ * @param {boolean} [props.disabled=false]  - If `true`, control is disabled.
  */
 export const AdvancedColorPicker = (props) => {
 	const {
@@ -97,6 +98,8 @@ export const AdvancedColorPicker = (props) => {
 				value: 'gradient'
 			}
 		],
+
+		disabled = false,
 	} = props;
 
 	const showProjectColor = types.find(({ value }) => value === 'project') !== undefined;
@@ -113,11 +116,12 @@ export const AdvancedColorPicker = (props) => {
 				customSingleValueDisplayComponent={CustomValueDisplay}
 				isClearable={false}
 				isSearchable={false}
+				disabled={disabled}
 			/>
 
 			<br />
 
-			{type === 'project' && showProjectColor &&
+			{type === 'project' && showProjectColor && !disabled &&
 				<ColorPaletteCustom
 					value={colorProject}
 					colors={typeof colorsProject == 'undefined' ? globalColors : colorsProject}
@@ -125,7 +129,7 @@ export const AdvancedColorPicker = (props) => {
 				/>
 			}
 
-			{type === 'solid' && showSolidColor &&
+			{type === 'solid' && showSolidColor && !disabled &&
 				<ColorPicker
 					color={colorSolid}
 					onChangeComplete={onChangeSolid}
@@ -133,7 +137,7 @@ export const AdvancedColorPicker = (props) => {
 				/>
 			}
 
-			{type === 'gradient' && showGradient &&
+			{type === 'gradient' && showGradient && !disabled &&
 				<GradientPicker
 					value={colorGradient}
 					onChange={onChangeGradient}

--- a/scripts/components/advanced-color-picker/docs/story.js
+++ b/scripts/components/advanced-color-picker/docs/story.js
@@ -52,6 +52,19 @@ export const component = () => {
 
 	const extractedProjectColor = colors.find(({ slug }) => slug === projectColor);
 
+	const getBackground = () => {
+		switch (type) {
+			case 'project':
+				return extractedProjectColor?.color;
+			case 'solid':
+				return solidColor?.hex;
+			case 'gradient':
+				return gradient;
+			default:
+				return 'transparent';
+		}
+	};
+
 	return (
 		<>
 			<div style={{
@@ -59,7 +72,7 @@ export const component = () => {
 				height: '3rem',
 				padding: '1rem',
 				boxShadow: 'inset 0 0 0 1px #FFFFFF, 0 0 0 1px #F0F0F0',
-				background: type === '' ? 'transparent' : (type === 'project' ? extractedProjectColor?.color : (type === 'solid' ? solidColor?.hex : gradient)),
+				background: getBackground(),
 				borderRadius: '6rem',
 				margin: '0 0 1rem 8.5rem'
 			}}></div>

--- a/scripts/components/alignment-toolbar/alignment-toolbar.js
+++ b/scripts/components/alignment-toolbar/alignment-toolbar.js
@@ -28,6 +28,7 @@ export const AlignmentToolbarType = {
  * @param {React.Component?} props.label                  - Tooltip of the picker button (if not shown inline).
  * @param {string} props.title                            - Component/block name.
  * @param {boolean} [props.showInline=false]              - If `true`, the controls are displayed inline instead of a dropdown button.
+ * @param {boolean} [props.disabled=false]                - If `true`, control is disabled.
  */
 export const AlignmentToolbar = (props) => {
 	const {
@@ -38,6 +39,7 @@ export const AlignmentToolbar = (props) => {
 		label,
 		title = type === AlignmentToolbarType.TEXT ? __('text', 'eightshift-frontend-libs') : __('items', 'eightshift-frontend-libs'),
 		showInline = false,
+		disabled = false,
 	} = props;
 
 	const showAlignStart = options.includes('left');
@@ -137,6 +139,7 @@ export const AlignmentToolbar = (props) => {
 			isInline={showInline}
 			isToolbarButton
 			isInToolbar
+			disabled={disabled}
 		/>
 	);
 };

--- a/scripts/components/collapsable-component-use-toggle/collapsable-component-use-toggle.js
+++ b/scripts/components/collapsable-component-use-toggle/collapsable-component-use-toggle.js
@@ -39,6 +39,14 @@ export const CollapsableComponentUseToggle = ({
 		return children;
 	}
 
+	const getIcon = () => {
+		if (!checked) {
+			return icons.chevronDown;
+		}
+
+		return isOpen ? icons.chevronUp : icons.chevronDown;
+	};
+
 	return (
 		<BaseControl className={componentClasses}>
 			<div className='es-collapsable-component-use-toggle__trigger'>
@@ -60,7 +68,7 @@ export const CollapsableComponentUseToggle = ({
 					isTertiary
 					onClick={() => setIsOpen(!isOpen)}
 					className='es-collapsable-component-use-toggle__expander'
-					icon={!checked ? icons.chevronDown : (isOpen ? icons.chevronUp : icons.chevronDown)}
+					icon={getIcon()}
 					disabled={disabled || (showUseToggle && !checked)}
 				/>
 			</div>

--- a/scripts/components/color-picker-component/color-picker-component.js
+++ b/scripts/components/color-picker-component/color-picker-component.js
@@ -122,6 +122,22 @@ export const ColorPickerComponent = ({
 		}
 	};
 
+	if (!label) {
+		return (
+			<>
+				<Button
+					isSecondary
+					onClick={openPicker}
+					icon={getButtonIcon()}
+					iconSize={24}
+					ref={ref}
+				/>
+
+				{colorPicker}
+			</>
+		);
+	}
+
 	return (
 		<>
 			<div className='es-flex-between'>

--- a/scripts/components/color-picker-component/color-picker-component.js
+++ b/scripts/components/color-picker-component/color-picker-component.js
@@ -31,6 +31,7 @@ export const ColorPickerType = {
  * @param {string} [props.pickerPopupTitle]             - Color picker popup title.
  * @param {string} [props.resetLabel]                   - 'Reset' button tooltip.
  * @param {string} [props.type=ColorPickerType.GENERIC] - Color picker type (determines the visual style of the picker).
+ * @param {string} props.tooltip                        - Tooltip of the picker button (if label not provided).
  */
 export const ColorPickerComponent = ({
 	colors,
@@ -41,6 +42,7 @@ export const ColorPickerComponent = ({
 	pickerPopupTitle = __('Pick a color', 'eightshift-frontend-libs'),
 	resetLabel = __('Reset', 'eightshift-frontend-libs'),
 	type = ColorPickerType.GENERIC,
+	tooltip,
 }) => {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -54,6 +56,23 @@ export const ColorPickerComponent = ({
 	const resetValue = () => {
 		onChange(undefined);
 		setIsDropdownOpen(false);
+	};
+
+	const getTooltipText = () => {
+		if (tooltip) {
+			return tooltip;
+		}
+
+		switch (type) {
+			case ColorPickerType.BACKGROUND_COLOR:
+				return __('Background color', 'eightshift-frontend-libs');
+			case ColorPickerType.TEXT_COLOR:
+				return __('Text color', 'eightshift-frontend-libs');
+			case ColorPickerType.TEXT_HIGHLIGHT_COLOR:
+				return __('Text highlight color', 'eightshift-frontend-libs');
+			default:
+				return __('Color', 'eightshift-frontend-libs');
+		}
 	};
 
 	const colorPicker = isDropdownOpen && (
@@ -131,6 +150,7 @@ export const ColorPickerComponent = ({
 					icon={getButtonIcon()}
 					iconSize={24}
 					ref={ref}
+					label={getTooltipText()}
 				/>
 
 				{colorPicker}

--- a/scripts/components/color-picker-component/color-picker-component.js
+++ b/scripts/components/color-picker-component/color-picker-component.js
@@ -32,6 +32,7 @@ export const ColorPickerType = {
  * @param {string} [props.resetLabel]                   - 'Reset' button tooltip.
  * @param {string} [props.type=ColorPickerType.GENERIC] - Color picker type (determines the visual style of the picker).
  * @param {string} props.tooltip                        - Tooltip of the picker button (if label not provided).
+ * @param {boolean} [props.disabled=false]  - If `true`, control is disabled.
  */
 export const ColorPickerComponent = ({
 	colors,
@@ -43,6 +44,7 @@ export const ColorPickerComponent = ({
 	resetLabel = __('Reset', 'eightshift-frontend-libs'),
 	type = ColorPickerType.GENERIC,
 	tooltip,
+	disabled = false,
 }) => {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -151,6 +153,7 @@ export const ColorPickerComponent = ({
 					iconSize={24}
 					ref={ref}
 					label={getTooltipText()}
+					disabled={disabled}
 				/>
 
 				{colorPicker}
@@ -169,6 +172,7 @@ export const ColorPickerComponent = ({
 					icon={getButtonIcon()}
 					iconSize={24}
 					ref={ref}
+					disabled={disabled}
 				/>
 			</div>
 

--- a/scripts/components/custom-select/custom-select.js
+++ b/scripts/components/custom-select/custom-select.js
@@ -7,6 +7,19 @@ import { SortableContainer, SortableElement, sortableHandle } from 'react-sortab
 import AsyncSelect from "react-select/async";
 
 /**
+ * Determines the CustomSelect border style.
+ * 
+ * - `MATCH_WP` - matches the WP Admin theme color.
+ * - `BLACK` - black.
+ * - `DEFAULT` - 80% gray.
+ */
+export const CustomSelectStyle = {
+	MATCH_WP: 'var(--wp-admin-theme-color, #111111)',
+	BLACK: 'hsla(0, 0%, 0%, 1)',
+	DEFAULT: 'hsla(0, 0%, 80%, 1)',
+};
+
+/**
  * A modern, flexible and customizable select menu.
  *
  * @param {object} props                                               - CustomSelect options.
@@ -16,6 +29,7 @@ import AsyncSelect from "react-select/async";
  * @param {array?} props.options                                       - Options to choose. Option should be in `{label: '', value: ''}` format.
  * @param {object} props.value                                         - Current value
  * @param {function} props.onChange                                    - Function called when the selection is changed.
+ * @param {boolean} [props.isCompact=false]                            - If `true`, the component will slightly reduce height so it fits nicely with WP Buttons and similar components.
  * @param {boolean} [props.isClearable=true]                           - If `true`, the currently selected item can be cleared. `null` is set as the value.
  * @param {boolean} [props.isSearchable=true]                          - If `true`, the options can be searched through.
  * @param {boolean} [props.closeMenuOnSelect=false]                    - If single-select mode is active, after a selection is made the dropdown is closed.
@@ -34,6 +48,7 @@ import AsyncSelect from "react-select/async";
  * @param {boolean} [props.hideSelected=false]                         - If set to `true`, the selected option is hidden from the menu.
  * @param {string} [props.loadingMessage='Loading']                    - Text to display when loading options.
  * @param {string} [props.noOptionsMessage='No options']               - Text to display when no options are available.
+ * @param {CustomSelectStyle} [props.style=CustomSelectStyle.DEFAULT]  - Style of the CustomSelect.
  */
 export const CustomSelect = (props) => {
 	const {
@@ -43,6 +58,7 @@ export const CustomSelect = (props) => {
 		options,
 		value,
 		onChange,
+		isCompact = false,
 		isClearable = true,
 		isSearchable = true,
 		closeMenuOnSelect = false,
@@ -61,6 +77,7 @@ export const CustomSelect = (props) => {
 		hideSelected = false,
 		loadingMessage = __('Loading', 'eightshift-frontend-libs'),
 		noOptionsMessage = __('No options', 'eightshift-frontend-libs'),
+		style = CustomSelectStyle.DEFAULT,
 	} = props;
 
 	const { Option, SingleValue, MultiValue, MultiValueLabel } = components;
@@ -251,7 +268,7 @@ export const CustomSelect = (props) => {
 			closeMenuOnSelect={closeMenuOnSelect}
 			theme={(theme) => ({
 				...theme,
-				borderRadius: 3,
+				borderRadius: 2,
 				colors: {
 					...theme.colors,
 					primary25: 'hsla(0, 0%, 90%, 1)',
@@ -284,6 +301,9 @@ export const CustomSelect = (props) => {
 					borderBottomLeftRadius: state.menuIsOpen ? 0 : state.theme.borderRadius,
 					borderBottomRightRadius: state.menuIsOpen ? 0 : state.theme.borderRadius,
 					zIndex: state.menuIsOpen ? 4 : null,
+					borderColor: style,
+					minHeight: isCompact ? '2.25rem' : provided.minHeight,
+					height: isCompact ? '2.25rem' : provided.height,
 				}),
 				option: (provided, state) => ({
 					...provided,
@@ -293,6 +313,27 @@ export const CustomSelect = (props) => {
 					transition: 'all 0.3s ease-out',
 					...(state.isSelected ? { backgroundColor: 'var(--wp-admin-theme-color, #111111)' } : {}),
 				}),
+				valueContainer: (provided) => {
+					if (!isCompact) {
+						return provided;
+					}
+
+					return {
+						...provided,
+						padding: '0 0.5rem',
+						height: '2.125rem',
+					};
+				},
+				indicatorsContainer: (provided) => {
+					if (!isCompact) {
+						return provided;
+					}
+
+					return {
+						...provided,
+						height: '2.125rem',
+					};
+				}
 			}}
 		/>
 	);

--- a/scripts/components/heading-level/heading-level.js
+++ b/scripts/components/heading-level/heading-level.js
@@ -14,6 +14,7 @@ import { OptionPicker } from '@eightshift/frontend-libs/scripts/components';
  * @param {number?} props.selectedLevel  - Currently selected heading level.
  * @param {function} props.onChange      - Function called when the selection is changed.
  * @param {string} [props.title]         - Function called when the selection is changed.
+ * @param {boolean} [props.disabled=false]  - If `true`, control is disabled.
  */
 export const HeadingLevel = (props) => {
 	const {
@@ -23,6 +24,7 @@ export const HeadingLevel = (props) => {
 		selectedLevel,
 		onChange,
 		title = __('Heading', 'eightshift-frontend-libs'),
+		disabled = false,
 	} = props;
 
 	const options = range(minLevel, maxLevel + 1).map((level) => {
@@ -42,6 +44,7 @@ export const HeadingLevel = (props) => {
 			isInline={inline}
 			isToolbarButton
 			isInToolbar
+			disabled={disabled}
 		/>
 	);
 };

--- a/scripts/components/icon-toggle/icon-toggle.js
+++ b/scripts/components/icon-toggle/icon-toggle.js
@@ -10,6 +10,7 @@ import { ToggleControl } from '@wordpress/components';
  * @param {function} props.onChange    - `onChange` handler from the `ToggleSwitch`.
  * @param {React.Component} props.icon - Icon to display.
  * @param {string?} props.help         - Help text to display.
+ * @param {boolean} [props.disabled=false]  - If `true`, control is disabled.
  */
 export const IconToggle = ({
 	label,
@@ -17,6 +18,7 @@ export const IconToggle = ({
 	onChange,
 	icon,
 	help,
+	disabled = false,
 }) => {
 	return (
 		<div className={`es-icon-toggle es-icon-toggle--reverse ${icon && help ? 'has-help' : ''}`}>
@@ -26,8 +28,8 @@ export const IconToggle = ({
 				checked={checked}
 				onChange={onChange}
 				help={help}
+				disabled={disabled}
 			/>
 		</div>
-
 	);
 };

--- a/scripts/components/link-edit-component/link-edit-component.js
+++ b/scripts/components/link-edit-component/link-edit-component.js
@@ -20,6 +20,7 @@ import { icons, truncateMiddle } from '@eightshift/frontend-libs/scripts';
  * @param {string} [props.removeLinkTooltip]      - 'Remove link' button tooltip.
  * @param {string} [props.editUrlLabel]           - 'Edit URL' button label (when URL is set).
  * @param {string} [props.addUrlLabel]            - 'Add URL' button label (when URL is not set).
+ * @param {boolean} [props.disabled=false]        - If `true`, control is disabled.
  */
 export const LinkEditComponent = ({
 	url,
@@ -33,6 +34,7 @@ export const LinkEditComponent = ({
 	removeLinkTooltip = __('Remove link'),
 	editUrlLabel = __('Edit URL'),
 	addUrlLabel = __('Add URL'),
+	disabled = false,
 }) => {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -130,6 +132,7 @@ export const LinkEditComponent = ({
 					onClick={openLinkControl}
 					icon={url?.length > 0 ? icons.editOptions : icons.add}
 					iconSize={24}
+					disabled={disabled}
 				>
 					{url?.length > 0 ? editUrlLabel : addUrlLabel}
 				</Button>
@@ -141,6 +144,7 @@ export const LinkEditComponent = ({
 						icon={icons.trash}
 						iconSize={24}
 						label={removeLinkTooltip}
+						disabled={disabled}
 					/>
 				}
 			</div>

--- a/scripts/components/link-toolbar-button/link-toolbar-button.js
+++ b/scripts/components/link-toolbar-button/link-toolbar-button.js
@@ -18,6 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * @param {boolean} [props.showNewTabOption=true] - If `true`, displays the 'Open in new tab' toggle.
  * @param {string} [props.newTabOptionName]       - Name of the 'Opens in new tab' option shown in the interface.
  * @param {string} [props.removeLinkLabel]        - Label on the 'Remove link' button.
+ * @param {boolean} [props.disabled=false]        - If `true`, control is disabled.
  */
 export const LinkToolbarButton = ({
 	url,
@@ -29,6 +30,7 @@ export const LinkToolbarButton = ({
 	showNewTabOption = true,
 	newTabOptionName = __('Open in new tab'),
 	removeLinkLabel = __('Remove link'),
+	disabled = false,
 }) => {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -120,11 +122,12 @@ export const LinkToolbarButton = ({
 	return (
 		<>
 			<ToolbarButton
-				name="link"
+				name='link'
 				icon={link}
 				title={sprintf(__('%s URL'), title)}
 				onClick={openLinkControl}
 				isActive={url?.length}
+				disabled={disabled}
 			/>
 			{linkControl}
 		</>

--- a/scripts/components/option-picker/option-picker.js
+++ b/scripts/components/option-picker/option-picker.js
@@ -19,6 +19,7 @@ import { icons } from '@eightshift/frontend-libs/scripts';
  * @param {React.Component?} [props.buttonIcon]         - If set, the button that opens a dropdown option picker displays the set (JSX SVG) icon. Otherwise, the icon of the currently selected option (or first option if nothing selected) is used.
  * @param {boolean} [props.showToggleButtonLabel=false] - If `true`, the text label is shown next to the icon of the button that opens a dropdown option picker.
  * @param {boolean} [props.unsetOnClick=false] 			- If `true`, and you click a option that is currently selected, the value will be unset (set to `undefined`).
+ * @param {boolean} [props.disabled=false]              - If `true`, control is disabled.
  */
 export const OptionPicker
 	= ({
@@ -35,6 +36,7 @@ export const OptionPicker
 		buttonIcon,
 		showToggleButtonLabel = false,
 		unsetOnClick = false,
+		disabled = false,
 	}) => {
 		/**
 		 * Gets the onChange callback with will (un)set a value
@@ -83,6 +85,7 @@ export const OptionPicker
 					label: controlLabel,
 					showTooltip: true,
 					isPressed: isToggleButtonActive,
+					disabled: disabled,
 				}}
 				popoverProps={{
 					position: popoverPosition,

--- a/scripts/components/simple-vertical-single-select/simple-vertical-single-select.js
+++ b/scripts/components/simple-vertical-single-select/simple-vertical-single-select.js
@@ -11,10 +11,12 @@ import { BaseControl, Button } from '@wordpress/components';
  * @param {string} props.options.label            - Option description.
  * @param {boolean} props.options.isActive        - Boolean to determine if the current option is active.
  * @param {React.Component?} [props.options.icon] - Icon beside the option.
+ * @param {boolean} [props.disabled=false]        - If `true`, control is disabled.
  */
 export const SimpleVerticalSingleSelect = ({
 	label,
 	options,
+	disabled = false,
 }) => {
 	return (
 		<BaseControl label={label}>
@@ -26,6 +28,7 @@ export const SimpleVerticalSingleSelect = ({
 						icon={icon}
 						iconSize={24}
 						isPressed={isActive}
+						disabled={disabled}
 					>
 						{label}
 					</Button>


### PR DESCRIPTION
# Description

- ColorPickerComponent doesn't show a label if not passed, so it can be used inline now
- ColorPickerComponent now shows tooltip (customizeable, has defaults) on the button if no label is passed
- CustomSelect can now be switched to compact mode (height reduced a bit) so it can nicely integrate with other options inline
- CustomSelect has a `style` property now (currenlty tweaks border color)
- most of the components can now be disabled through an attribute

# Screenshots / Videos

For example, on more complext projects a (part of the) Paragraph options can be made more compact with the new CustomSelect styles.

![image](https://user-images.githubusercontent.com/77000136/149134381-6eb6d7d1-a132-41b2-940d-0d3cd447d8dc.png)

# Linked documentation PR

\-
