### PR TITLE
Fix for advanced color picker

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,6 +1,7 @@
 // All exports are sorted in alphabetical order.
 
 // Components
+export { AdvancedColorPicker } from './components/advanced-color-picker/advanced-color-picker';
 export {
 	AlignmentToolbar,
 	AlignmentToolbarType


### PR DESCRIPTION
Changelog:
- add Advanced color picker to `scripts/index.js` that was causing a crash