### PR TITLE
Improve header / footer accessibility, fix #534

### DIFF
--- a/blocks/init/src/Blocks/components/drawer/assets/drawer.js
+++ b/blocks/init/src/Blocks/components/drawer/assets/drawer.js
@@ -1,3 +1,5 @@
+import { debounce } from '@eightshift/frontend-libs/scripts/helpers/debounce';
+
 export class Drawer {
 	constructor({ drawerElement }) {
 		this.drawerElement = drawerElement;
@@ -21,19 +23,27 @@ export class Drawer {
 	
 	openMobileMenu() {
 		this.trigger?.classList.add(this.CLASS_MENU_OPEN);
-		document.body.classList.add(this.CLASS_MENU_OPEN);
+		this.drawerElement.style.display = 'block';
+
+		const addClass = debounce(() => document.body.classList.add(this.CLASS_MENU_OPEN), 300);
+		addClass();
+
 		this.preventScroll();
 	}
 	
 	closeMobileMenu() {
 		this.trigger?.classList.remove(this.CLASS_MENU_OPEN);
 		document.body.classList.remove(this.CLASS_MENU_OPEN);
+
+		const setDisplayNone = debounce(() => this.drawerElement.style.display = 'none', 300);
+		setDisplayNone();
+
 		this.enableScroll();
 	}
 	
 	init() {
 		this.trigger.addEventListener('click', () => {
-			if (document.body.classList.contains(this.CLASS_MENU_OPEN)) {
+			if (this.trigger?.classList.contains(this.CLASS_MENU_OPEN)) {
 				this.closeMobileMenu();
 			} else {
 				this.openMobileMenu();

--- a/blocks/init/src/Blocks/components/drawer/assets/drawer.js
+++ b/blocks/init/src/Blocks/components/drawer/assets/drawer.js
@@ -2,15 +2,9 @@ export class Drawer {
 	constructor({ drawerElement }) {
 		this.drawerElement = drawerElement;
 		this.CLASS_MENU_OPEN = 'is-menu-open';
-		this.CLASS_OVERLAY_IS_SHOWING = 'page-overlay-shown';
 		this.CLASS_NO_SCROLL = 'u-no-scroll';
 
-		const overlaySelector = drawerElement?.dataset?.overlay;
 		const triggerSelector = drawerElement?.dataset?.trigger;
-
-		if (overlaySelector) {
-			this.overlay = document.querySelector(`.${overlaySelector}`);
-		}
 
 		if (triggerSelector) {
 			this.trigger = document.querySelector(`.${triggerSelector}`);
@@ -26,29 +20,17 @@ export class Drawer {
 	}
 	
 	openMobileMenu() {
-		if (this.overlay) {
-			document.body.classList.add(this.CLASS_OVERLAY_IS_SHOWING);
-			this.trigger?.classList.add(this.CLASS_MENU_OPEN);
-		}
-
+		this.trigger?.classList.add(this.CLASS_MENU_OPEN);
 		document.body.classList.add(this.CLASS_MENU_OPEN);
 		this.preventScroll();
 	}
 	
 	closeMobileMenu() {
-		if (this.overlay) {
-			document.body.classList.remove(this.CLASS_OVERLAY_IS_SHOWING);
-			this.trigger?.classList.remove(this.CLASS_MENU_OPEN);
-		}
-
+		this.trigger?.classList.remove(this.CLASS_MENU_OPEN);
 		document.body.classList.remove(this.CLASS_MENU_OPEN);
 		this.enableScroll();
 	}
 	
-	closeMobileMenuOnOverlayClick() {
-		this.overlay?.addEventListener('click', () => this.closeMobileMenu());
-	}
-
 	init() {
 		this.trigger.addEventListener('click', () => {
 			if (document.body.classList.contains(this.CLASS_MENU_OPEN)) {
@@ -57,7 +39,6 @@ export class Drawer {
 				this.openMobileMenu();
 			}
 		});
-
-		this.closeMobileMenuOnOverlayClick();
 	}
+
 }

--- a/blocks/init/src/Blocks/components/drawer/drawer-style.scss
+++ b/blocks/init/src/Blocks/components/drawer/drawer-style.scss
@@ -2,10 +2,9 @@
 	$menu: &;
 	position: fixed;
 	top: auto;
-	height: 100%;
+	height: 0;
 	width: 100%;
 	margin: auto;
-	padding: var(--global-gutters-default);
 
 	display: none;
 	overflow-x: hidden;
@@ -13,9 +12,11 @@
 	background: var(--global-colors-white);
 
 	box-shadow: 0 0 0.15rem rgba(var(--global-colors-black), 0.2);
+	transition: height 0.3s ease-in-out;
 
 	&.is-open {
 		display: block;
+		padding: var(--global-gutters-default);
 		pointer-events: auto;
 	}
 }
@@ -24,7 +25,7 @@ body.is-menu-open {
 	overflow: hidden;
 
 	.drawer {
-		display: block;
 		pointer-events: auto;
+		height: 100%;
 	}
 }

--- a/blocks/init/src/Blocks/components/drawer/drawer-style.scss
+++ b/blocks/init/src/Blocks/components/drawer/drawer-style.scss
@@ -3,44 +3,19 @@
 	position: fixed;
 	top: auto;
 	height: 100%;
-	z-index: var(--global-z-index-drawer);
+	width: 100%;
 	margin: auto;
 	padding: var(--global-gutters-default);
-	display: block;
-	background: var(--global-colors-white);
-	width: var(--drawer-scoped-width, 22.5rem);
-	transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+
+	display: none;
 	overflow-x: hidden;
+
+	background: var(--global-colors-white);
+
 	box-shadow: 0 0 0.15rem rgba(var(--global-colors-black), 0.2);
 
-	&__position {
-		pointer-events: none;
-
-		&--left {
-			left: 0;
-			transform: translate3d(-100%, 0, 0);
-		}
-
-		&--right {
-			right: 0;
-			transform: translate3d(100%, 0, 0);
-		}
-
-		&--top {
-			--drawer-scoped-width: 100%;
-			transform: translate3d(0, -100%, 0);
-		}
-
-		&--behind {
-			--drawer-scoped-width: 100%;
-			transform: translate3d(0, 0, 0);
-			opacity: 0;
-		}
-	}
-
 	&.is-open {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
+		display: block;
 		pointer-events: auto;
 	}
 }
@@ -49,8 +24,7 @@ body.is-menu-open {
 	overflow: hidden;
 
 	.drawer {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
+		display: block;
 		pointer-events: auto;
 	}
 }

--- a/blocks/init/src/Blocks/components/drawer/drawer.php
+++ b/blocks/init/src/Blocks/components/drawer/drawer.php
@@ -23,22 +23,19 @@ $componentJsClass = $manifest['componentJsClass'] ?? '';
 
 $drawerMenu = Components::checkAttr('drawerMenu', $attributes, $manifest);
 $drawerTrigger = Components::checkAttr('drawerTrigger', $attributes, $manifest);
-$drawerOverlay = Components::checkAttr('drawerOverlay', $attributes, $manifest);
-$drawerPosition = Components::checkAttr('drawerPosition', $attributes, $manifest);
 
 $drawerClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
 	Components::selector($componentJsClass, $componentJsClass),
-	Components::selector($drawerPosition, $componentClass, 'position', $drawerPosition),
 ]);
 
 ?>
 <div
 	class="<?php echo \esc_attr($drawerClass); ?>"
 	data-trigger="<?php echo \esc_attr($drawerTrigger); ?>"
-	data-overlay="<?php echo \esc_attr($drawerOverlay); ?>"
 >
 	<?php echo \wp_kses_post($drawerMenu); ?>
 </div>
+

--- a/blocks/init/src/Blocks/components/drawer/manifest.json
+++ b/blocks/init/src/Blocks/components/drawer/manifest.json
@@ -5,25 +5,16 @@
 	"componentJsClass": "js-drawer",
 	"example": {
 		"attributes": {
-			"drawerPosition": "left",
 			"drawerMenu": "Menu component",
 			"drawerTrigger": "",
-			"drawerOverlay": "",
 			"drawerUse": true
 		}
 	},
 	"attributes": {
-		"drawerPosition": {
-			"type": "string",
-			"default": "left"
-		},
 		"drawerMenu": {
 			"type": "string"
 		},
 		"drawerTrigger": {
-			"type": "string"
-		},
-		"drawerOverlay": {
 			"type": "string"
 		},
 		"drawerUse": {

--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -15,7 +15,7 @@ if (!$hamburgerUse) {
 	return;
 }
 
-$hamburgerLabel = Components::checkAttr('hamburgerLabel', $attributes, $manifest) ?: __('Menu', 'a11y-testing');
+$hamburgerLabel = Components::checkAttr('hamburgerLabel', $attributes, $manifest) ?? __('Menu', 'a11y-testing');
 $componentClass = $manifest['componentClass'] ?? '';
 $additionalClass = $attributes['additionalClass'] ?? '';
 $blockClass = $attributes['blockClass'] ?? '';

--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -15,6 +15,7 @@ if (!$hamburgerUse) {
 	return;
 }
 
+$hamburgerLabel = Components::checkAttr('hamburgerLabel', $attributes, $manifest) ?: __('Menu', 'a11y-testing');
 $componentClass = $manifest['componentClass'] ?? '';
 $additionalClass = $attributes['additionalClass'] ?? '';
 $blockClass = $attributes['blockClass'] ?? '';
@@ -35,7 +36,7 @@ $iconMidClass = Components::selector($componentClass, $componentClass, 'icon', '
 $iconBtmClass = Components::selector($componentClass, $componentClass, 'icon', 'btm');
 ?>
 
-<button class="<?php echo esc_attr($hamburgerClass); ?>">
+<button class="<?php echo esc_attr($hamburgerClass); ?>" label="<?php echo esc_attr($hamburgerLabel); ?>" aria-label="<?php echo esc_attr($hamburgerLabel); ?>">
 	<svg class="<?php echo \esc_attr($iconClass); ?>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<rect class="<?php echo \esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="1.5" stroke="black" />
 		<path class="<?php echo \esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />

--- a/blocks/init/src/Blocks/components/hamburger/manifest.json
+++ b/blocks/init/src/Blocks/components/hamburger/manifest.json
@@ -14,8 +14,7 @@
 			"default": true
 		},
 		"hamburgerLabel": {
-			"type": "string",
-			"default": ""
+			"type": "string"
 		}
 	}
 }

--- a/blocks/init/src/Blocks/components/hamburger/manifest.json
+++ b/blocks/init/src/Blocks/components/hamburger/manifest.json
@@ -12,6 +12,10 @@
 		"hamburgerUse": {
 			"type": "boolean",
 			"default": true
+		},
+		"hamburgerLabel": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
+++ b/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
@@ -24,6 +24,7 @@ $layoutThreeColumnsLeft = Components::checkAttr('layoutThreeColumnsLeft', $attri
 $layoutThreeColumnsCenter = Components::checkAttr('layoutThreeColumnsCenter', $attributes, $manifest);
 $layoutThreeColumnsRight = Components::checkAttr('layoutThreeColumnsRight', $attributes, $manifest);
 $layoutThreeColumnsHtmlTag = Components::checkAttr('layoutThreeColumnsHtmlTag', $attributes, $manifest);
+$layoutThreeColumnsAriaRole = Components::checkAttr('layoutThreeColumnsAriaRole', $attributes, $manifest);
 
 $layoutClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
@@ -51,7 +52,12 @@ $columnRightClass = Components::classnames([
 
 ?>
 
-<<?php echo esc_attr($layoutThreeColumnsHtmlTag); ?> class="<?php echo \esc_attr($layoutClass); ?>">
+<<?php echo esc_attr($layoutThreeColumnsHtmlTag); ?>
+	class="<?php echo \esc_attr($layoutClass); ?>"
+	<?php if ($layoutThreeColumnsAriaRole) { ?>
+		role="<?php echo \esc_attr($layoutThreeColumnsAriaRole); ?>"
+	<?php } ?>
+>
 
 		<?php if ($layoutThreeColumnsLeft) { ?>
 			<div class="<?php echo \esc_attr($columnLeftClass); ?>">

--- a/blocks/init/src/Blocks/components/layout-three-columns/manifest.json
+++ b/blocks/init/src/Blocks/components/layout-three-columns/manifest.json
@@ -24,6 +24,10 @@
 			"type": "string",
 			"default": "div"
 		},
+		"layoutThreeColumnsAriaRole": {
+			"type": "string",
+			"default": ""
+		},
 		"layoutThreeColumnsUse": {
 			"type": "boolean",
 			"default": true

--- a/blocks/init/src/Blocks/components/layout-three-columns/manifest.json
+++ b/blocks/init/src/Blocks/components/layout-three-columns/manifest.json
@@ -25,8 +25,7 @@
 			"default": "div"
 		},
 		"layoutThreeColumnsAriaRole": {
-			"type": "string",
-			"default": ""
+			"type": "string"
 		},
 		"layoutThreeColumnsUse": {
 			"type": "boolean",


### PR DESCRIPTION
# Description

This PR, [along with the one on infinum/eightshift-boilerplate](https://github.com/infinum/eightshift-frontend-libs/pull/540), fixes the accessibility issues reported in #534.

* `layout-three-columns` now supports setting an ARIA role for it
* `hamburger` now supports labels
* `drawer` has been refactored to improve accessibility and make the component simpler:
  * page overlay and positioning support was removed, which fixes the interactive semantics issues with page overlays, and also IMO looks a bit cleaner
  * drawers now use `display: none` to hide themselves, instead of visibility hacks, which fixes the tab order issues

# Screenshots / Videos

<!--- Show us what you did. -->
The new drawer:
<img width="888" alt="Screenshot 2022-01-18 at 10 10 29" src="https://user-images.githubusercontent.com/1742806/149909634-08bbc83d-bca0-4ea5-9237-00a699b3e3ca.png">

Tab order demo:

https://user-images.githubusercontent.com/1742806/149909699-38b292c6-b9fa-4da6-9c8c-7e475b85ef51.mov

