### PR TITLE
Fix appender button styles when it's not the only child

### DIFF
--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -627,8 +627,9 @@ body {
 		// to make it easier to hit.
 		.block-list-appender.wp-block:not(:only-child) {
 			.block-list-appender__toggle.block-editor-button-block-appender {
-				width: 100%;
+				width: auto;
 				height: 100%;
+				margin: 0 auto;
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Changed styles of appender button in Gutenberg editor when button is not the only child in component, now button is centered instead of full length.

# Screenshots / Videos

![image](https://user-images.githubusercontent.com/24306614/152006584-c82ab8b0-cd10-4f1d-9ec5-bbb86720c4e2.png)
