### PR TITLE
Fix warnings on hsl function

### DIFF
--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -897,33 +897,33 @@ body {
 	.es-collapsable-component-use-toggle {
 		border-radius: 0.5rem;
 		box-shadow: 0 0 0 0 transparent;
-	
+
 		transition: {
 			property: box-shadow, padding, margin;
 			timing-function: ease-out;
 			duration: 0.2s;
 		}
-	
+
 		&__trigger {
 			display: grid;
 			align-items: center;
 			grid-template-columns: 1fr auto;
 			grid-template-rows: auto;
 			gap: 1rem;
-	
+
 			border-bottom: 1px solid transparent;
-	
+
 			transition: {
 				property: border-color;
 				timing-function: ease-out;
 				duration: 0.3s;
 			}
-	
+
 			.components-base-control,
 			.components-base-control__field {
 				margin: 0 !important;
 			}
-	
+
 			span,
 			label {
 				display: block;
@@ -936,7 +936,7 @@ body {
 				text-transform: uppercase;
 				user-select: none;
 				color: currentColor;
-	
+
 				transition: {
 					property: color;
 					timing-function: ease-out;
@@ -944,48 +944,48 @@ body {
 				}
 			}
 		}
-	
+
 		&__toggle {
 			.components-base-control__field {
 				flex-grow: 1;
 			}
 		}
-	
+
 		&.is-open {
 			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #194BD4);
 			padding: 0.5rem;
-	
+
 			margin-left: -0.5rem;
 			margin-right: -0.5rem;
-	
+
 			.es-collapsable-component-use-toggle__trigger {
 				color: var(--wp-admin-theme-color, #194BD4);
-				border-bottom-color: hsl(0 0 96%);
+				border-bottom-color: hsl(0deg 0% 96%);
 				padding-bottom: 0.5rem;
 			}
-	
+
 			span,
 			label {
 				opacity: 1;
 			}
-	
+
 			.es-collapsable-component-use-toggle__trigger {
 				margin-bottom: 0.5rem;
 			}
 		}
-	
+
 		&__expander {
 			width: 2.25rem;
 			height: 2rem;
 			padding: 0;
-	
-			box-shadow: inset 0 0 0 1px hsl(0 0 96%);
+
+			box-shadow: inset 0 0 0 1px hsl(0deg 0% 96%);
 			border-radius: 100rem;
-	
+
 			svg {
 				width: 1rem !important;
 				height: 1rem !important;
 			}
 		}
-	}	
+	}
 }


### PR DESCRIPTION
# Description

Fix a couple of warnings in build output for `override-editor.scss` regarding the `hsl()` function.
One warning is still present, but that's related to normalize package and we can only wait for the update.

Removed a lot of whitespace from empty lines.