### PR TITLE
Accordion A11y improvements

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion-style.scss
+++ b/blocks/init/src/Blocks/components/accordion/accordion-style.scss
@@ -45,10 +45,6 @@
 			color: var(--global-colors-white);
 			background-color: var(--global-colors-ocean);
 		}
-
-		&:active {
-			color: inherit;
-		}
 	}
 
 	&__icon {

--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -49,6 +49,7 @@ $accordionPanelClass = Components::classnames([
 $accordionContentClass = Components::selector($componentClass, $componentClass, 'content');
 
 $uniqueAccordionId = Components::getUnique();
+$uniqueAccordionTriggerId = Components::getUnique();
 ?>
 
 <div
@@ -61,6 +62,7 @@ $uniqueAccordionId = Components::getUnique();
 		aria-label="<?php echo esc_html($accordionTitle); ?>"
 		aria-controls="<?php echo \esc_attr($uniqueAccordionId); ?>"
 		aria-expanded="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
+		id="<?php echo \esc_attr($uniqueAccordionTriggerId); ?>"
 	>
 		<?php echo \esc_html($accordionTitle); ?>
 		<div class="<?php echo \esc_attr($accordionIconClass); ?>" aria-hidden="true" >
@@ -72,6 +74,7 @@ $uniqueAccordionId = Components::getUnique();
 		role="region"
 		class="<?php echo \esc_attr($accordionPanelClass); ?>"
 		aria-hidden="<?php echo \esc_attr($accordionIsOpen ? 'false' : 'true'); ?>"
+		aria-labelledby="<?php echo \esc_attr($uniqueAccordionTriggerId); ?>"
 		id="<?php echo esc_attr($uniqueAccordionId); ?>"
 	>
 		<div class="<?php echo \esc_attr($accordionContentClass); ?>">

--- a/blocks/init/src/Blocks/components/accordion/assets/accordion.js
+++ b/blocks/init/src/Blocks/components/accordion/assets/accordion.js
@@ -63,8 +63,8 @@ export class Accordion {
 		}
 
 		item.dataset.accordionOpen = false;
-		item.querySelector(this.triggerSelector)?.setAttribute("aria-expanded", "false");
-		panel.setAttribute("aria-hidden", "true");
+		item.querySelector(this.triggerSelector)?.setAttribute('aria-expanded', 'false');
+		panel.setAttribute('aria-hidden', 'true');
 	}
 
 	open(item, panel) {
@@ -74,8 +74,8 @@ export class Accordion {
 
 		panel.style.setProperty('--max-height', `${panel.scrollHeight}px`);
 		item.dataset.accordionOpen = true;
-		item.querySelector(this.triggerSelector)?.setAttribute("aria-expanded", "true");
-		panel.setAttribute("aria-hidden", "false");
+		item.querySelector(this.triggerSelector)?.setAttribute('aria-expanded', 'true');
+		panel.setAttribute('aria-hidden', 'false');
 
 		if (item.dataset.closeOthers === 'true') {
 			this.closeAdjacent(item);

--- a/blocks/init/src/Blocks/components/accordion/assets/accordion.js
+++ b/blocks/init/src/Blocks/components/accordion/assets/accordion.js
@@ -63,8 +63,8 @@ export class Accordion {
 		}
 
 		item.dataset.accordionOpen = false;
-		item.ariaExpanded = false;
-		panel.ariaHidden = true;
+		item.querySelector(this.triggerSelector)?.setAttribute("aria-expanded", "false");
+		panel.setAttribute("aria-hidden", "true");
 	}
 
 	open(item, panel) {
@@ -74,8 +74,8 @@ export class Accordion {
 
 		panel.style.setProperty('--max-height', `${panel.scrollHeight}px`);
 		item.dataset.accordionOpen = true;
-		item.ariaExpanded = true;
-		panel.ariaHidden = false;
+		item.querySelector(this.triggerSelector)?.setAttribute("aria-expanded", "true");
+		panel.setAttribute("aria-hidden", "false");
 
 		if (item.dataset.closeOthers === 'true') {
 			this.closeAdjacent(item);


### PR DESCRIPTION
# Description

Fixes some a11y issues with the accordion component:

* setting ARIA attributes using `Element` properties isn't supported in Firefox, so this was changed to `setAttribute`
* the accordion panel region didn't have the `aria-labelledby` attribute
* when clicking on the accordion, text would flash between black and white a bit because the hover state changed it to white, but the active state had `color: inherit;` set - which would inherit the color disregarding the hover state

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
