### PR TITLE
Change color scheme to match WCAG contrast requirements

### DIFF
--- a/blocks/init/src/Blocks/components/button/manifest.json
+++ b/blocks/init/src/Blocks/components/button/manifest.json
@@ -139,7 +139,7 @@
 			"yellow": [
 				{
 					"variable": {
-						"button-color": "var(--global-colors-white)",
+						"button-color": "var(--global-colors-black)",
 						"button-color-hover": "var(--global-colors-white)",
 						"button-background-color": "var(--global-colors-yellow)",
 						"button-background-color-hover": "var(--global-colors-black)",
@@ -151,7 +151,7 @@
 			"ocean": [
 				{
 					"variable": {
-						"button-color": "var(--global-colors-white)",
+						"button-color": "var(--global-colors-black)",
 						"button-color-hover": "var(--global-colors-white)",
 						"button-background-color": "var(--global-colors-ocean)",
 						"button-background-color-hover": "var(--global-colors-black)",
@@ -163,7 +163,7 @@
 			"green": [
 				{
 					"variable": {
-						"button-color": "var(--global-colors-white)",
+						"button-color": "var(--global-colors-black)",
 						"button-color-hover": "var(--global-colors-white)",
 						"button-background-color": "var(--global-colors-green)",
 						"button-background-color-hover": "var(--global-colors-black)",

--- a/blocks/init/src/Blocks/components/lists/manifest.json
+++ b/blocks/init/src/Blocks/components/lists/manifest.json
@@ -131,7 +131,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-primary)",
 						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-yellow)"
+						"lists-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -140,7 +140,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-black)",
 						"lists-link-color": "var(--global-colors-primary)",
-						"lists-link-color-hover": "var(--global-colors-primary)"
+						"lists-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -148,8 +148,8 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-green)",
-						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-primary)"
+						"lists-link-color": "var(--global-colors-white)",
+						"lists-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -157,8 +157,8 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-ocean)",
-						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-red)"
+						"lists-link-color": "var(--global-colors-white)",
+						"lists-link-color-hover": "var(--global-colors-green)"
 					}
 				}
 			],
@@ -166,8 +166,8 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-yellow)",
-						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-primary)"
+						"lists-link-color": "var(--global-colors-white)",
+						"lists-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -176,7 +176,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-blue)",
 						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-yellow)"
+						"lists-link-color-hover": "var(--global-colors-primary)"
 					}
 				}
 			],
@@ -185,7 +185,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-red)",
 						"lists-link-color": "var(--global-colors-black)",
-						"lists-link-color-hover": "var(--global-colors-yellow)"
+						"lists-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -194,7 +194,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-cream)",
 						"lists-link-color": "var(--global-colors-yellow)",
-						"lists-link-color-hover": "var(--global-colors-red)"
+						"lists-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -203,7 +203,7 @@
 					"variable": {
 						"lists-color": "var(--global-colors-white)",
 						"lists-link-color": "var(--global-colors-yellow)",
-						"lists-link-color-hover": "var(--global-colors-primary)"
+						"lists-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -211,8 +211,8 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-eightshift)",
-						"lists-link-color": "var(--global-colors-green)",
-						"lists-link-color-hover": "var(--global-colors-yellow)"
+						"lists-link-color": "var(--global-colors-blue)",
+						"lists-link-color-hover": "var(--global-colors-primary)"
 					}
 				}
 			],
@@ -220,8 +220,8 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-dew)",
-						"lists-link-color": "var(--global-colors-primary)",
-						"lists-link-color-hover": "var(--global-colors-yellow)"
+						"lists-link-color": "var(--global-colors-ocean)",
+						"lists-link-color-hover": "var(--global-colors-white)"
 					}
 				}
 			],
@@ -229,7 +229,7 @@
 				{
 					"variable": {
 						"lists-color": "var(--global-colors-mist)",
-						"lists-link-color": "var(--global-colors-blue)",
+						"lists-link-color": "var(--global-colors-ocean)",
 						"lists-link-color-hover": "var(--global-colors-green)"
 					}
 				}

--- a/blocks/init/src/Blocks/components/paragraph/manifest.json
+++ b/blocks/init/src/Blocks/components/paragraph/manifest.json
@@ -92,7 +92,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-primary)",
 						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-yellow)"
+						"paragraph-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -101,7 +101,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-black)",
 						"paragraph-link-color": "var(--global-colors-primary)",
-						"paragraph-link-color-hover": "var(--global-colors-primary)"
+						"paragraph-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -109,8 +109,8 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-green)",
-						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-primary)"
+						"paragraph-link-color": "var(--global-colors-white)",
+						"paragraph-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -118,8 +118,8 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-ocean)",
-						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-red)"
+						"paragraph-link-color": "var(--global-colors-white)",
+						"paragraph-link-color-hover": "var(--global-colors-green)"
 					}
 				}
 			],
@@ -127,8 +127,8 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-yellow)",
-						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-primary)"
+						"paragraph-link-color": "var(--global-colors-white)",
+						"paragraph-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -137,7 +137,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-blue)",
 						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-yellow)"
+						"paragraph-link-color-hover": "var(--global-colors-primary)"
 					}
 				}
 			],
@@ -146,7 +146,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-red)",
 						"paragraph-link-color": "var(--global-colors-black)",
-						"paragraph-link-color-hover": "var(--global-colors-yellow)"
+						"paragraph-link-color-hover": "var(--global-colors-blue)"
 					}
 				}
 			],
@@ -155,7 +155,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-cream)",
 						"paragraph-link-color": "var(--global-colors-yellow)",
-						"paragraph-link-color-hover": "var(--global-red)"
+						"paragraph-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -164,7 +164,7 @@
 					"variable": {
 						"paragraph-color": "var(--global-colors-white)",
 						"paragraph-link-color": "var(--global-colors-yellow)",
-						"paragraph-link-color-hover": "var(--global-colors-primary)"
+						"paragraph-link-color-hover": "var(--global-colors-ocean)"
 					}
 				}
 			],
@@ -172,8 +172,8 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-eightshift)",
-						"paragraph-link-color": "var(--global-colors-green)",
-						"paragraph-link-color-hover": "var(--global-colors-yellow)"
+						"paragraph-link-color": "var(--global-colors-blue)",
+						"paragraph-link-color-hover": "var(--global-colors-primary)"
 					}
 				}
 			],
@@ -181,8 +181,8 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-dew)",
-						"paragraph-link-color": "var(--global-colors-primary)",
-						"paragraph-link-color-hover": "var(--global-colors-yellow)"
+						"paragraph-link-color": "var(--global-colors-ocean)",
+						"paragraph-link-color-hover": "var(--global-colors-white)"
 					}
 				}
 			],
@@ -190,7 +190,7 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-mist)",
-						"paragraph-link-color": "var(--global-colors-blue)",
+						"paragraph-link-color": "var(--global-colors-ocean)",
 						"paragraph-link-color-hover": "var(--global-colors-green)"
 					}
 				}

--- a/blocks/init/src/Blocks/manifest.json
+++ b/blocks/init/src/Blocks/manifest.json
@@ -40,7 +40,7 @@
 			{
 				"name": "Primary",
 				"slug": "primary",
-				"color": "#662ED6"
+				"color": "#6200EA"
 			},
 			{
 				"name": "Black",
@@ -60,42 +60,42 @@
 			{
 				"name": "Ocean",
 				"slug": "ocean",
-				"color": "#155D7E"
+				"color": "#00B8D4"
 			},
 			{
 				"name": "Green",
 				"slug": "green",
-				"color": "#175959"
+				"color": "#00E676"
 			},
 			{
 				"name": "Red",
 				"slug": "red",
-				"color": "#AF1818"
+				"color": "#B30024"
 			},
 			{
 				"name": "Yellow",
 				"slug": "yellow",
-				"color": "#77460D"
+				"color": "#FFEA00"
 			},
 			{
 				"name": "Blue",
 				"slug": "blue",
-				"color": "#285786"
+				"color": "#0040F0"
 			},
 			{
 				"name": "Mist",
 				"slug": "mist",
-				"color": "#F0F8FF"
+				"color": "#F1FBFE"
 			},
 			{
 				"name": "Dew",
 				"slug": "dew",
-				"color": "#FBF9FF"
+				"color": "#FAF8FC"
 			},
 			{
 				"name": "Cream",
 				"slug": "cream",
-				"color": "#F4F3F0"
+				"color": "#FFFBF5"
 			},
 			{
 				"name": "Eightshift",

--- a/blocks/init/src/Blocks/manifest.json
+++ b/blocks/init/src/Blocks/manifest.json
@@ -40,7 +40,7 @@
 			{
 				"name": "Primary",
 				"slug": "primary",
-				"color": "#9973E3"
+				"color": "#662ED6"
 			},
 			{
 				"name": "Black",
@@ -60,27 +60,27 @@
 			{
 				"name": "Ocean",
 				"slug": "ocean",
-				"color": "#44AEDE"
+				"color": "#155D7E"
 			},
 			{
 				"name": "Green",
 				"slug": "green",
-				"color": "#29A3A3"
+				"color": "#175959"
 			},
 			{
 				"name": "Red",
 				"slug": "red",
-				"color": "#E84E4E"
+				"color": "#AF1818"
 			},
 			{
 				"name": "Yellow",
 				"slug": "yellow",
-				"color": "#F99922"
+				"color": "#77460D"
 			},
 			{
 				"name": "Blue",
 				"slug": "blue",
-				"color": "#4184C7"
+				"color": "#285786"
 			},
 			{
 				"name": "Mist",


### PR DESCRIPTION
# Description

This PR changes the default color scheme so the contrast with white or black foregrounds is in line with WCAG AAA requirements (as they're mostly used as background colors for white or black text, mostly on buttons and as wrapper backgrounds).

As this is WCAG AAA compliant, lesser contrast (which will probably happen if the foreground colors aren't exactly `#fff` or `#000`) should still be AA-level compliant.

As project usually define their own color schemes, this PR will only affect the starter theme. As discussed previously with @iruzevic, these colors don't have brand meaning and were chosen arbitrarily, so these changes are mostly the same.

I'll work on a contrast warning later on.

# Screenshots / Videos
This is what buttons now look like:
<img width="216" alt="Screenshot 2022-02-08 at 15 28 56" src="https://user-images.githubusercontent.com/1742806/153007846-434721b5-cb15-4bca-9766-968794c06cea.png">


# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
Relevant: https://webaim.org/resources/contrastchecker/
