### PR TITLE
Improvements for small viewports

### DIFF
--- a/blocks/init/src/Blocks/components/header/header-style.scss
+++ b/blocks/init/src/Blocks/components/header/header-style.scss
@@ -9,7 +9,7 @@
 
 	width: 100%;
 	max-width: var(--global-containers-default);
-	height: var(--header-scoped-height, 5rem);
+	min-height: var(--header-scoped-height, 5rem);
 
 	background: var(--header-scoped-background, var(--global-colors-white));
 

--- a/blocks/init/src/Blocks/components/heading/heading-style.scss
+++ b/blocks/init/src/Blocks/components/heading/heading-style.scss
@@ -4,4 +4,5 @@
 	color: var(--heading-color, var(--global-colors-black, currentColor));
 	font-size: var(--heading-font-size, 1.5rem);
 	line-height: var(--heading-line-height, 1.25);
+	overflow-wrap: anywhere;
 }

--- a/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns-style.scss
+++ b/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns-style.scss
@@ -2,4 +2,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.75rem;
 }

--- a/blocks/init/src/Blocks/components/lists/lists-style.scss
+++ b/blocks/init/src/Blocks/components/lists/lists-style.scss
@@ -7,6 +7,7 @@
 
 	li {
 		margin-left: 1.1rem;
+		overflow-wrap: anywhere;
 
 		&::marker {
 			color: var(--lists-marker-color, currentColor);

--- a/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
+++ b/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
@@ -25,6 +25,7 @@ $menu-horizontal: (
 		align-items: center;
 		justify-content: center;
 		transition: 0.3s color ease-in-out;
+		overflow-wrap: anywhere;
 
 		@include link($menu-horizontal, link-modifiers);
 	}

--- a/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
+++ b/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
@@ -15,6 +15,8 @@ $menu-horizontal: (
 	height: 100%;
 	display: flex;
 	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.75rem;
 
 	&__link {
 		text-decoration: none;
@@ -22,7 +24,6 @@ $menu-horizontal: (
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		padding: 0 0.75rem;
 		transition: 0.3s color ease-in-out;
 
 		@include link($menu-horizontal, link-modifiers);

--- a/blocks/init/src/Blocks/components/menu/styles/vertical/menu-vertical-style.scss
+++ b/blocks/init/src/Blocks/components/menu/styles/vertical/menu-vertical-style.scss
@@ -18,6 +18,7 @@ $menu-vertical: (
 		text-decoration: none;
 		transition: 0.3s color ease-in-out;
 		padding: map-get-strict($menu-vertical, link-padding);
+		overflow-wrap: anywhere;
 
 		@include link($menu-vertical, link-modifiers);
 	}

--- a/blocks/init/src/Blocks/components/paragraph/paragraph-style.scss
+++ b/blocks/init/src/Blocks/components/paragraph/paragraph-style.scss
@@ -3,6 +3,7 @@
 	color: var(--paragraph-color, var(--global-colors-black, currentColor));
 	font-size: var(--paragraph-font-size, 1rem);
 	line-height: var(--paragraph-line-height, 1.5);
+	overflow-wrap: anywhere;
 
 	a {
 		cursor: pointer;

--- a/blocks/init/src/Blocks/custom/featured-posts/components/featured-posts-options.js
+++ b/blocks/init/src/Blocks/custom/featured-posts/components/featured-posts-options.js
@@ -3,7 +3,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import _ from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { PanelBody, RangeControl } from '@wordpress/components';
-import { CustomSelect, icons, IconLabel, BlockIcon, ucfirst, getAttrKey, IconToggle } from '@eightshift/frontend-libs/scripts';
+import { Fragment } from '@wordpress/element';
+import { CustomSelect, icons, IconLabel, BlockIcon, ucfirst, getAttrKey, IconToggle, Responsive } from '@eightshift/frontend-libs/scripts';
 import manifest from '../manifest.json';
 import { unescapeHTML } from '@eightshift/frontend-libs/scripts/helpers/text-helpers';
 
@@ -13,7 +14,8 @@ export const FeaturedPostsOptions = ({ attributes, setAttributes }) => {
 		allowed: {
 			postTypes,
 			taxonomies
-		}
+		},
+		attributes: manifestAttributes,
 	} = manifest;
 
 	const {
@@ -24,10 +26,11 @@ export const FeaturedPostsOptions = ({ attributes, setAttributes }) => {
 			terms,
 			posts,
 		},
-		featuredPostsItemsPerLine,
 		featuredPostsShowItems,
 		featuredPostsExcludeCurrentPost,
 	} = attributes;
+
+	const breakpoints = ['large', 'desktop', 'tablet', 'mobile'];
 
 	// Fetch all post types.
 	// Filter allowed post types defined in the block manifest.
@@ -199,14 +202,27 @@ export const FeaturedPostsOptions = ({ attributes, setAttributes }) => {
 
 			<hr />
 
-			<RangeControl
-				label={<IconLabel icon={icons.itemsPerRow} label={__('Items per row', 'eightshift-frontend-libs')} />}
-				value={featuredPostsItemsPerLine}
-				onChange={(value) => setAttributes({ [getAttrKey('featuredPostsItemsPerLine', attributes, manifest)]: value })}
-				min={manifestOptions.featuredPostsItemsPerLine.min}
-				max={manifestOptions.featuredPostsItemsPerLine.max}
-				step={manifestOptions.featuredPostsItemsPerLine.step}
-			/>
+			<Responsive label={<IconLabel icon={icons.itemPerRow} label={__('Items per row', 'eightshift-frontend-libs')} />}>
+				{breakpoints.map((keyName) => {
+					const point = ucfirst(keyName);
+					const attr = point === 'Large' ? `${getAttrKey('featuredPostsItemsPerLine', attributes, manifest)}` : `${getAttrKey('featuredPostsItemsPerLine', attributes, manifest)}${point}`;
+
+					return (
+						<Fragment key={keyName}>
+							<RangeControl
+								label={<IconLabel icon={icons[`screen${point}`]} label={point} />}
+								onChange={(value) => setAttributes({ [attr]: value })}
+								resetFallbackValue={manifestAttributes[attr].default}
+								value={attributes[attr]}
+								min={manifestOptions.featuredPostsItemsPerLine.min}
+								max={manifestOptions.featuredPostsItemsPerLine.max}
+								step={manifestOptions.featuredPostsItemsPerLine.step}
+								allowReset
+							/>
+						</Fragment>
+					);
+				})}
+			</Responsive>
 
 			<RangeControl
 				label={<IconLabel icon={icons.totalItems} label={__('Maximum items', 'eightshift-frontend-libs')} />}

--- a/blocks/init/src/Blocks/custom/featured-posts/manifest.json
+++ b/blocks/init/src/Blocks/custom/featured-posts/manifest.json
@@ -42,6 +42,18 @@
 			"type": "integer",
 			"default": 4
 		},
+		"featuredPostsItemsPerLineDesktop": {
+			"type": "integer",
+			"default": 4
+		},
+		"featuredPostsItemsPerLineTablet": {
+			"type": "integer",
+			"default": 3
+		},
+		"featuredPostsItemsPerLineMobile": {
+			"type": "integer",
+			"default": 2
+		},
 		"featuredPostsShowItems": {
 			"type": "integer"
 		},
@@ -52,6 +64,14 @@
 		"featuredPostsServerSideRender": {
 			"type": "boolean",
 			"default": false
+		}
+	},
+	"responsiveAttributes": {
+		"featuredPostsItemsPerLine": {
+			"large": "featuredPostsItemsPerLine",
+			"desktop": "featuredPostsItemsPerLineDesktop",
+			"tablet": "featuredPostsItemsPerLineTablet",
+			"mobile": "featuredPostsItemsPerLineMobile"
 		}
 	},
 	"allowed": {


### PR DESCRIPTION
# Description

This PR is focused on preventing overflows and clipping in regards to [WCAG AA SC 1. 4. 10.: Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html).

* Makes the number of items per row in the Featured Posts block a responsive attribute, which was previously a single value for all viewports.
* Stops the header component from overflowing by setting `min-height` instead of `height`
* Makes use of `flex-wrap` in `layout-three-columns` and `menu-horizontal` so it doesn't clip or overflow


# Screenshots / Videos

<!--- Show us what you did. -->

Wrapping:
![Screenshot 2022-02-16 at 10 31 40](https://user-images.githubusercontent.com/1742806/154235778-1450e6b1-d7d2-47b3-a102-e9b6f4f50a8a.png)

![Screenshot 2022-02-16 at 10 32 11](https://user-images.githubusercontent.com/1742806/154235869-01c69e09-c0e9-4495-b500-8197338d8637.png)


Responsive Featured posts:
https://user-images.githubusercontent.com/1742806/154236174-898535ae-6f24-41cf-b3fb-f30d0d14e283.mov

Non-overflowing content:
![Screenshot 2022-02-16 at 10 35 52](https://user-images.githubusercontent.com/1742806/154236549-d64f3b27-3336-4f64-976a-d0eacea235a2.png)
![Screenshot 2022-02-16 at 10 37 01](https://user-images.githubusercontent.com/1742806/154236754-6f701b8d-6787-4d47-9316-141b09fb71c0.png)

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
