### PR TITLE
Add outline on focus to button component

### DIFF
--- a/blocks/init/src/Blocks/components/button/button-style.scss
+++ b/blocks/init/src/Blocks/components/button/button-style.scss
@@ -37,4 +37,12 @@
 		--button-scoped-background-color: var(--global-colors-light);
 		--button-cursor: not-allowed;
 	}
+
+	&:focus {
+		outline: {
+			color: var(--button-outline-focus-color, var(--button-scoped-background-color, var(--button-background-color, var(--global-colors-primary))));
+			style: var(--button-outline-focus-style, dotted);
+			width: var(--button-outline-focus-width, 0.25rem);
+		}
+	}
 }


### PR DESCRIPTION
# Description

This PR adds a visible outline to the `button` component on `:focus`, with support for overriding the outline color, style and width using CSS variables.

It currently defaults to the same color as the background color if the outline color isn't set.

Note that `:focus` "is generally triggered when the user clicks or taps on an element or selects it with the keyboard's Tab key", and that `:focus-visible` [is in Safari TP](https://caniuse.com/css-focus-visible), so we'd have to polyfill to use it.

# Screenshots / Videos

<!--- Show us what you did. -->
![Screenshot 2022-02-24 at 14 22 58](https://user-images.githubusercontent.com/1742806/155532087-05a18867-a8dd-4a57-aa65-57e8bdd6722c.png)

