### PR TITLE
Carousel A11y improvements

### DIFF
--- a/blocks/init/src/Blocks/custom/carousel/assets/carousel-slider.js
+++ b/blocks/init/src/Blocks/custom/carousel/assets/carousel-slider.js
@@ -27,7 +27,9 @@ export class CarouselSlider {
 			modules: [
 				Navigation, Pagination, A11y
 			],
-			a11y: true,
+			a11y: {
+				slideRole: 'figure',
+			},
 			keyboard: {
 				enabled: true,
 			},

--- a/blocks/init/src/Blocks/custom/carousel/assets/carousel-slider.js
+++ b/blocks/init/src/Blocks/custom/carousel/assets/carousel-slider.js
@@ -1,4 +1,4 @@
-import Swiper, { Navigation, Pagination } from 'swiper';
+import Swiper, { Navigation, Pagination, A11y } from 'swiper';
 import globalManifest from './../../../manifest.json';
 
 export class CarouselSlider {
@@ -25,8 +25,9 @@ export class CarouselSlider {
 			slidesPerView: 1,
 			spaceBetween: 10,
 			modules: [
-				Navigation, Pagination
+				Navigation, Pagination, A11y
 			],
+			a11y: true,
 			keyboard: {
 				enabled: true,
 			},

--- a/blocks/init/src/Blocks/custom/carousel/carousel.php
+++ b/blocks/init/src/Blocks/custom/carousel/carousel.php
@@ -52,10 +52,10 @@ $paginationClass = Components::classnames([
 	</div>
 
 	<?php if ($carouselShowPrevNext) { ?>
-		<button class="<?php echo \esc_attr($prevButtonClass); ?>">
+		<button class="<?php echo \esc_attr($prevButtonClass); ?>" aria-label="<?php echo esc_attr__('Previous slide', 'eightshift-frontend-libs'); ?>">
 			<?php echo $manifest['resources']['prevIcon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</button>
-		<button class="<?php echo \esc_attr($nextButtonClass); ?>">
+		<button class="<?php echo \esc_attr($nextButtonClass); ?>" aria-label="<?php echo esc_attr__('Next slide', 'eightshift-frontend-libs'); ?>">
 			<?php echo $manifest['resources']['nextIcon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</button>
 	<?php } ?>


### PR DESCRIPTION
# Description

This PR:
* adds an ARIA label to the carousel navigation arrows
* enables the Swiper A11y module, which provides decent ARIA semantics for Swiper-rendered DOM elements
  * this is set to their default configuration, which seems sensible enough for everything apart from the `slideRole`, which I've explicitly overridden to `figure` for semantic correctness, and because we don't have a nice way to set labels for the default `group` roles on slide containers
