### PR TITLE
A11y: Small improvements to heading and paragraph components

### DIFF
--- a/blocks/init/src/Blocks/components/heading/heading.php
+++ b/blocks/init/src/Blocks/components/heading/heading.php
@@ -24,6 +24,10 @@ $selectorClass = $attributes['selectorClass'] ?? $componentClass;
 $headingContent = Components::checkAttr('headingContent', $attributes, $manifest);
 $headingLevel = Components::checkAttr('headingLevel', $attributes, $manifest);
 
+if (!$headingContent) {
+	return;
+}
+
 $headingClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),

--- a/blocks/init/src/Blocks/components/heading/heading.php
+++ b/blocks/init/src/Blocks/components/heading/heading.php
@@ -39,10 +39,8 @@ $headingLevel = $headingLevel ? "h{$headingLevel}" : 'h2';
 $unique = Components::getUnique();
 ?>
 
+<?php echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+
 <<?php echo esc_attr($headingLevel); ?> class="<?php echo esc_attr($headingClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
-
-	<?php echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-
 	<?php echo wp_kses_post($headingContent); ?>
-
 </<?php echo esc_attr($headingLevel); ?>>

--- a/blocks/init/src/Blocks/components/paragraph/paragraph.php
+++ b/blocks/init/src/Blocks/components/paragraph/paragraph.php
@@ -36,10 +36,8 @@ $paragraphClass = Components::classnames([
 ]);
 ?>
 
-<p class="<?php echo \esc_attr($paragraphClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
-	<?php
-		echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+<?php echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
-		echo \wp_kses_post($paragraphContent);
-	?>
+<p class="<?php echo \esc_attr($paragraphClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+	<?php echo \wp_kses_post($paragraphContent); ?>
 </p>

--- a/blocks/init/src/Blocks/components/paragraph/paragraph.php
+++ b/blocks/init/src/Blocks/components/paragraph/paragraph.php
@@ -25,6 +25,10 @@ $selectorClass = $attributes['selectorClass'] ?? $componentClass;
 
 $paragraphContent = Components::checkAttr('paragraphContent', $attributes, $manifest);
 
+if (!$paragraphContent) {
+	return;
+}
+
 $paragraphClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),


### PR DESCRIPTION
# Description

This PR:
* makes sure we render headings and paragraphs only if they have content
* moves `outputCssVariables` call to be outside `<h_>` and `<p>` tags (i.e. renders the `<style>` tag in heading/paragraph's parent node)
  * this is a large a11y improvement, as  `<style>` tag contents in an `<h_>` tag are for some reason read out by VoiceOver and included in Rotor navigation. imagine hearing `.heading[data-id='09d71c93caf0cd36f8713560cde6ef26'] {` instead of an actual heading

