### PR TITLE
A11y: Use list markup for card groups

### DIFF
--- a/blocks/init/src/Blocks/custom/featured-categories/featured-categories-style.scss
+++ b/blocks/init/src/Blocks/custom/featured-categories/featured-categories-style.scss
@@ -1,4 +1,7 @@
 .block-featured-categories {
+	list-style-type: none;
+	padding: 0;
+
 	display: grid;
 	grid-template-columns: var(--featured-categories-columns, repeat(2, 1fr));
 	grid-auto-rows: 1fr;

--- a/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
+++ b/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
@@ -26,7 +26,7 @@ if (!$taxonomyName) {
 }
 ?>
 
-<div
+<ul
 	class="<?php echo \esc_attr($blockClass); ?>"
 	data-id="<?php echo \esc_attr($unique); ?>"
 >
@@ -72,8 +72,8 @@ if (!$taxonomyName) {
 		}
 		?>
 
-		<div class="<?php echo esc_attr("{$blockClass}__item"); ?>">
+		<li class="<?php echo esc_attr("{$blockClass}__item"); ?>">
 			<?php echo Components::render('card', $cardProps); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</div>
+		</li>
 	<?php } ?>
-</div>
+</ul>

--- a/blocks/init/src/Blocks/custom/featured-posts/featured-posts-style.scss
+++ b/blocks/init/src/Blocks/custom/featured-posts/featured-posts-style.scss
@@ -1,4 +1,7 @@
 .block-featured-posts {
+	list-style-type: none;
+	padding: 0;
+
 	display: grid;
 	grid-template-columns: var(--featured-posts-columns, repeat(2, 1fr));
 	grid-auto-rows: 1fr;

--- a/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
+++ b/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
@@ -25,7 +25,7 @@ global $post;
 
 ?>
 
-<div
+<ul
 	class="<?php echo esc_attr($blockClass); ?>"
 	data-items-per-line=<?php echo \esc_attr($featuredPostsItemsPerLine); ?>
 	data-id="<?php echo \esc_attr($unique); ?>"
@@ -104,12 +104,12 @@ global $post;
 				}
 				?>
 
-				<div class="<?php echo esc_attr("{$blockClass}__item"); ?>">
+				<li class="<?php echo esc_attr("{$blockClass}__item"); ?>">
 					<?php echo Components::render('card', $cardProps); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				</div>
+				</li>
 				<?php
 			}
 			\wp_reset_postdata();
 		}
 		?>
-</div>
+</ul>


### PR DESCRIPTION
# Description

This PR changes markup for card groups in `featured-posts` and `featured-categories` to unordered lists instead of `div`s for a better screen reader experience and improved semantics. It also adds CSS resets for lists to those blocks, so no visual changes occur.

See https://inclusive-components.design/cards/ for more information about this choice.
