### PR TITLE
Fix hamburger label conditional

### DIFF
--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -15,7 +15,11 @@ if (!$hamburgerUse) {
 	return;
 }
 
-$hamburgerLabel = Components::checkAttr('hamburgerLabel', $attributes, $manifest) ?? __('Menu', 'eightshift-frontend-libs');
+$hamburgerLabel = Components::checkAttr('hamburgerLabel', $attributes, $manifest);
+if (!$hamburgerLabel) {
+	$hamburgerLabel = __('Menu', 'eightshift-frontend-libs');
+}
+
 $componentClass = $manifest['componentClass'] ?? '';
 $additionalClass = $attributes['additionalClass'] ?? '';
 $blockClass = $attributes['blockClass'] ?? '';

--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -40,7 +40,7 @@ $iconMidClass = Components::selector($componentClass, $componentClass, 'icon', '
 $iconBtmClass = Components::selector($componentClass, $componentClass, 'icon', 'btm');
 ?>
 
-<button class="<?php echo esc_attr($hamburgerClass); ?>" label="<?php echo esc_attr($hamburgerLabel); ?>" aria-label="<?php echo esc_attr($hamburgerLabel); ?>">
+<button class="<?php echo esc_attr($hamburgerClass); ?>" label="<?php echo esc_attr($hamburgerLabel); ?>">
 	<svg class="<?php echo \esc_attr($iconClass); ?>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<rect class="<?php echo \esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="1.5" stroke="black" />
 		<path class="<?php echo \esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />


### PR DESCRIPTION
# Description

Fixes the hamburgerLabel conditional to work as expected, i.e. output `__('Menu', 'eightshift-frontend-libs')` when attribute is undefined. Sorry 😶‍🌫️ 

Also removes the `aria-label`, as `label` is sufficient.


