### PR TITLE
Fix lint errors after Eightshift Coding Standards 1.4 release

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -53,33 +53,33 @@ $uniqueAccordionTriggerId = Components::getUnique();
 ?>
 
 <div
-	class="<?php echo \esc_attr($accordionClass); ?>"
-	data-accordion-open="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
-	data-close-others="<?php echo \esc_attr($accordionCloseOthers ? 'true' : 'false'); ?>"
+	class="<?php echo esc_attr($accordionClass); ?>"
+	data-accordion-open="<?php echo esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
+	data-close-others="<?php echo esc_attr($accordionCloseOthers ? 'true' : 'false'); ?>"
 >
 	<button
-		class="<?php echo \esc_attr($accordionTriggerClass); ?>"
+		class="<?php echo esc_attr($accordionTriggerClass); ?>"
 		aria-label="<?php echo esc_html($accordionTitle); ?>"
-		aria-controls="<?php echo \esc_attr($uniqueAccordionId); ?>"
-		aria-expanded="<?php echo \esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
-		id="<?php echo \esc_attr($uniqueAccordionTriggerId); ?>"
+		aria-controls="<?php echo esc_attr($uniqueAccordionId); ?>"
+		aria-expanded="<?php echo esc_attr($accordionIsOpen ? 'true' : 'false'); ?>"
+		id="<?php echo esc_attr($uniqueAccordionTriggerId); ?>"
 	>
-		<?php echo \esc_html($accordionTitle); ?>
-		<div class="<?php echo \esc_attr($accordionIconClass); ?>" aria-hidden="true" >
-			<?php echo $manifest['resources']['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo esc_html($accordionTitle); ?>
+		<div class="<?php echo esc_attr($accordionIconClass); ?>" aria-hidden="true" >
+			<?php echo $manifest['resources']['icon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 		</div>
 	</button>
 
 	<div
 		role="region"
-		class="<?php echo \esc_attr($accordionPanelClass); ?>"
-		aria-hidden="<?php echo \esc_attr($accordionIsOpen ? 'false' : 'true'); ?>"
-		aria-labelledby="<?php echo \esc_attr($uniqueAccordionTriggerId); ?>"
+		class="<?php echo esc_attr($accordionPanelClass); ?>"
+		aria-hidden="<?php echo esc_attr($accordionIsOpen ? 'false' : 'true'); ?>"
+		aria-labelledby="<?php echo esc_attr($uniqueAccordionTriggerId); ?>"
 		id="<?php echo esc_attr($uniqueAccordionId); ?>"
 	>
-		<div class="<?php echo \esc_attr($accordionContentClass); ?>">
+		<div class="<?php echo esc_attr($accordionContentClass); ?>">
 			<?php
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 				echo $accordionContent;
 			?>
 		</div>

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -53,42 +53,42 @@ $buttonClass = Components::classnames([
 
 <?php if (! $buttonUrl) { ?>
 	<button
-		class="<?php echo \esc_attr($buttonClass); ?>"
+		class="<?php echo esc_attr($buttonClass); ?>"
 		<?php if (!empty($buttonId)) { ?>
-			id="<?php echo \esc_attr($buttonId); ?>"
+			id="<?php echo esc_attr($buttonId); ?>"
 		<?php } ?>
-		title="<?php echo \esc_attr($buttonContent); ?>"
+		title="<?php echo esc_attr($buttonContent); ?>"
 		<?php if (!empty($buttonAriaLabel)) { ?>
-			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+			aria-label="<?php echo esc_attr($buttonAriaLabel); ?>"
 		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"
 		<?php
 		foreach ($buttonAttrs as $key => $value) {
-			echo \wp_kses_post("{$key}=" . $value . " ");
+			echo wp_kses_post("{$key}=" . $value . " ");
 		}
 		?>
 	>
-		<?php echo \esc_html($buttonContent); ?>
+		<?php echo esc_html($buttonContent); ?>
 	</button>
 
 <?php } else { ?>
 	<a
-		href="<?php echo \esc_url($buttonUrl); ?>"
-		class="<?php echo \esc_attr($buttonClass); ?>"
+		href="<?php echo esc_url($buttonUrl); ?>"
+		class="<?php echo esc_attr($buttonClass); ?>"
 		<?php if (!empty($buttonId)) { ?>
-			id="<?php echo \esc_attr($buttonId); ?>"
+			id="<?php echo esc_attr($buttonId); ?>"
 		<?php } ?>
-		title="<?php echo \esc_attr($buttonContent); ?>"
+		title="<?php echo esc_attr($buttonContent); ?>"
 		<?php if (!empty($buttonAriaLabel)) { ?>
-			aria-label="<?php echo \esc_attr($buttonAriaLabel); ?>"
+			aria-label="<?php echo esc_attr($buttonAriaLabel); ?>"
 		<?php } ?>
 		data-id="<?php echo esc_attr($unique); ?>"
 		<?php
 		foreach ($buttonAttrs as $key => $value) {
-			echo \wp_kses_post("{$key}=" . $value . " ");
+			echo wp_kses_post("{$key}=" . $value . " ");
 		}
 		?>
 	>
-		<?php echo \esc_html($buttonContent); ?>
+		<?php echo esc_html($buttonContent); ?>
 	</a>
 <?php } ?>

--- a/blocks/init/src/Blocks/components/card/card.php
+++ b/blocks/init/src/Blocks/components/card/card.php
@@ -26,7 +26,7 @@ $cardClass = Components::classnames([
 
 ?>
 
-<div class="<?php echo \esc_attr($cardClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($cardClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/components/copyright/copyright.php
+++ b/blocks/init/src/Blocks/components/copyright/copyright.php
@@ -31,6 +31,6 @@ $copyrightClass = Components::classnames([
 ]);
 
 ?>
-<div class="<?php echo \esc_attr($copyrightClass); ?>">
-	<?php echo \esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); ?>
+<div class="<?php echo esc_attr($copyrightClass); ?>">
+	<?php echo esc_html("&copy; {$copyrightBy} {$copyrightYear} - {$copyrightContent}"); ?>
 </div>

--- a/blocks/init/src/Blocks/components/drawer/drawer.php
+++ b/blocks/init/src/Blocks/components/drawer/drawer.php
@@ -33,9 +33,9 @@ $drawerClass = Components::classnames([
 
 ?>
 <div
-	class="<?php echo \esc_attr($drawerClass); ?>"
-	data-trigger="<?php echo \esc_attr($drawerTrigger); ?>"
+	class="<?php echo esc_attr($drawerClass); ?>"
+	data-trigger="<?php echo esc_attr($drawerTrigger); ?>"
 >
-	<?php echo \wp_kses_post($drawerMenu); ?>
+	<?php echo wp_kses_post($drawerMenu); ?>
 </div>
 

--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -37,10 +37,10 @@ $iconBtmClass = Components::selector($componentClass, $componentClass, 'icon', '
 ?>
 
 <button class="<?php echo esc_attr($hamburgerClass); ?>" label="<?php echo esc_attr($hamburgerLabel); ?>" aria-label="<?php echo esc_attr($hamburgerLabel); ?>">
-	<svg class="<?php echo \esc_attr($iconClass); ?>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect class="<?php echo \esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="1.5" stroke="black" />
-		<path class="<?php echo \esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-		<path class="<?php echo \esc_attr($iconMidClass); ?>" d="M7.38464 16H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-		<path class="<?php echo \esc_attr($iconBtmClass); ?>" d="M7.38464 22.1538H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+	<svg class="<?php echo esc_attr($iconClass); ?>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect class="<?php echo esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="1.5" stroke="black" />
+		<path class="<?php echo esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path class="<?php echo esc_attr($iconMidClass); ?>" d="M7.38464 16H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path class="<?php echo esc_attr($iconBtmClass); ?>" d="M7.38464 22.1538H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
 	</svg>
 </button>

--- a/blocks/init/src/Blocks/components/head/head.php
+++ b/blocks/init/src/Blocks/components/head/head.php
@@ -18,7 +18,7 @@ $headName = Components::checkAttr('headName', $attributes, $manifest);
 ?>
 
 <?php if (isset($headCharset)) { ?>
-  <meta charset="<?php echo \esc_attr($headCharset); ?>" />
+  <meta charset="<?php echo esc_attr($headCharset); ?>" />
 <?php } ?>
 
 <!-- Responsive -->
@@ -37,22 +37,22 @@ $headName = Components::checkAttr('headName', $attributes, $manifest);
 
 <!-- Win phone Meta -->
 <?php if (isset($headName)) { ?>
-  <meta name="application-name" content="<?php echo \esc_attr($headName); ?>" />
+  <meta name="application-name" content="<?php echo esc_attr($headName); ?>" />
 <?php } ?>
 
 <!-- Apple -->
 <?php if (isset($headName)) { ?>
-  <meta name="apple-mobile-web-app-title" content="<?php echo \esc_attr($headName); ?>">
+  <meta name="apple-mobile-web-app-title" content="<?php echo esc_attr($headName); ?>">
 <?php } ?>
 
 <meta name="apple-mobile-web-app-capable" content="yes">
 
 <?php if (isset($headFavicon)) { ?>
-  <link rel="apple-touch-startup-image" href="<?php echo \esc_url($headFavicon); ?>">
+  <link rel="apple-touch-startup-image" href="<?php echo esc_url($headFavicon); ?>">
 <?php } ?>
 
 <!-- General -->
-<link rel="shortcut icon" href="<?php echo \esc_url($headFavicon); ?>" />
+<link rel="shortcut icon" href="<?php echo esc_url($headFavicon); ?>" />
 
 <?php
-echo Components::outputCssVariablesGlobal($globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo Components::outputCssVariablesGlobal($globalManifest); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped

--- a/blocks/init/src/Blocks/components/icon/icon.php
+++ b/blocks/init/src/Blocks/components/icon/icon.php
@@ -30,5 +30,5 @@ $iconClass = Components::classnames([
 
 ?>
 <i class="<?php echo esc_attr($iconClass); ?>">
-	<?php echo $manifest['icons'][$iconName]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo $manifest['icons'][$iconName]; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 </i>

--- a/blocks/init/src/Blocks/components/image/image.php
+++ b/blocks/init/src/Blocks/components/image/image.php
@@ -40,7 +40,7 @@ $imgClass = Components::classnames([
 ?>
 
 <?php if (isset($imageUrl['large']) && $imageUrl['large']) { ?>
-	<picture class="<?php echo \esc_attr($pictureClass); ?>" data-id="<?php echo esc_attr($unique); ?>" alt="<?php echo esc_attr($imageAlt); ?>">
+	<picture class="<?php echo esc_attr($pictureClass); ?>" data-id="<?php echo esc_attr($unique); ?>" alt="<?php echo esc_attr($imageAlt); ?>">
 
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -62,10 +62,10 @@ $imgClass = Components::classnames([
 				continue;
 			}
 
-			echo '<source srcset="' . \esc_url($item) . '" media="(max-width: ' . esc_attr($breakpointValue) . 'px)" />'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<source srcset="' . esc_url($item) . '" media="(max-width: ' . esc_attr($breakpointValue) . 'px)" />'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		<?php } ?>
 
-		<img src="<?php echo \esc_url($imageUrl['large']); ?>" class="<?php echo \esc_attr($imgClass); ?>" alt="<?php echo esc_attr($imageAlt); ?>" />
+		<img src="<?php echo esc_url($imageUrl['large']); ?>" class="<?php echo esc_attr($imgClass); ?>" alt="<?php echo esc_attr($imageAlt); ?>" />
 	</picture>
 <?php } ?>

--- a/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
+++ b/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
@@ -34,7 +34,7 @@ $jumbotronContentWrapClass = Components::selector($componentClass, $componentCla
 
 ?>
 
-<div class="<?php echo \esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
@@ -48,8 +48,8 @@ $jumbotronContentWrapClass = Components::selector($componentClass, $componentCla
 	);
 	?>
 
-	<div class="<?php echo \esc_attr($jumbotronContentClass); ?>">
-		<div class="<?php echo \esc_attr($jumbotronContentWrapClass); ?>">
+	<div class="<?php echo esc_attr($jumbotronContentClass); ?>">
+		<div class="<?php echo esc_attr($jumbotronContentWrapClass); ?>">
 			<?php
 			echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'heading',

--- a/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
+++ b/blocks/init/src/Blocks/components/layout-three-columns/layout-three-columns.php
@@ -53,32 +53,32 @@ $columnRightClass = Components::classnames([
 ?>
 
 <<?php echo esc_attr($layoutThreeColumnsHtmlTag); ?>
-	class="<?php echo \esc_attr($layoutClass); ?>"
+	class="<?php echo esc_attr($layoutClass); ?>"
 	<?php if ($layoutThreeColumnsAriaRole) { ?>
-		role="<?php echo \esc_attr($layoutThreeColumnsAriaRole); ?>"
+		role="<?php echo esc_attr($layoutThreeColumnsAriaRole); ?>"
 	<?php } ?>
 >
 
 		<?php if ($layoutThreeColumnsLeft) { ?>
-			<div class="<?php echo \esc_attr($columnLeftClass); ?>">
+			<div class="<?php echo esc_attr($columnLeftClass); ?>">
 				<?php
-					echo Components::ensureString($layoutThreeColumnsLeft); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo Components::ensureString($layoutThreeColumnsLeft); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 				?>
 			</div>
 		<?php } ?>
 
 		<?php if ($layoutThreeColumnsCenter) { ?>
-			<div class="<?php echo \esc_attr($columnCenterClass); ?>">
+			<div class="<?php echo esc_attr($columnCenterClass); ?>">
 				<?php
-					echo Components::ensureString($layoutThreeColumnsCenter); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo Components::ensureString($layoutThreeColumnsCenter); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 				?>
 			</div>
 		<?php } ?>
 
 		<?php if ($layoutThreeColumnsRight) { ?>
-			<div class="<?php echo \esc_attr($columnRightClass); ?>">
+			<div class="<?php echo esc_attr($columnRightClass); ?>">
 				<?php
-					echo Components::ensureString($layoutThreeColumnsRight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo Components::ensureString($layoutThreeColumnsRight); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 				?>
 			</div>
 		<?php } ?>

--- a/blocks/init/src/Blocks/components/loader/loader.php
+++ b/blocks/init/src/Blocks/components/loader/loader.php
@@ -31,5 +31,5 @@ $loaderClass = Components::classnames([
 ?>
 
 <div class="<?php echo esc_attr($loaderClass); ?>">
-	<?php echo $manifest['resources']['loader']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo $manifest['resources']['loader']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 </div>

--- a/blocks/init/src/Blocks/components/logo/logo.php
+++ b/blocks/init/src/Blocks/components/logo/logo.php
@@ -37,13 +37,13 @@ $imgClass = Components::classnames([
 
 ?>
 <a
-	class="<?php echo \esc_attr($logoClass); ?>"
-	href="<?php echo \esc_url($logoHref); ?>"
+	class="<?php echo esc_attr($logoClass); ?>"
+	href="<?php echo esc_url($logoHref); ?>"
 >
 	<img
-	src="<?php echo \esc_url($logoSrc); ?>"
-	alt="<?php echo \esc_attr($logoAlt); ?>"
-	title="<?php echo \esc_attr($logoTitle); ?>"
-	class="<?php echo \esc_attr($imgClass); ?>"
+	src="<?php echo esc_url($logoSrc); ?>"
+	alt="<?php echo esc_attr($logoAlt); ?>"
+	title="<?php echo esc_attr($logoTitle); ?>"
+	class="<?php echo esc_attr($imgClass); ?>"
 	/>
 </a>

--- a/blocks/init/src/Blocks/components/menu/menu.php
+++ b/blocks/init/src/Blocks/components/menu/menu.php
@@ -34,5 +34,5 @@ $bemMenu = Menu::bemMenu( // @phpstan-ignore-line will be fixed in the stubs.
 );
 
 if (!empty($bemMenu) && !$bemMenu) {
-	echo \esc_html($bemMenu);
+	echo esc_html($bemMenu);
 }

--- a/blocks/init/src/Blocks/components/modal/modal.php
+++ b/blocks/init/src/Blocks/components/modal/modal.php
@@ -38,37 +38,37 @@ $modalClass = Components::classnames([
 ?>
 
 <div
-	class="<?php echo \esc_attr($modalClass); ?>"
+	class="<?php echo esc_attr($modalClass); ?>"
 	<?php if (!empty($modalId)) { ?>
-		id="<?php echo \esc_attr($modalId); ?>"
+		id="<?php echo esc_attr($modalId); ?>"
 	<?php } ?>
 	aria-hidden="true"
 >
 	<div
-		<?php echo \esc_attr("data-{$componentJsToggleClass}-close"); ?>
-		class="<?php echo \esc_attr("{$componentClass}__overlay"); ?>"
+		<?php echo esc_attr("data-{$componentJsToggleClass}-close"); ?>
+		class="<?php echo esc_attr("{$componentClass}__overlay"); ?>"
 		tabIndex="-1"
 	>
 		<div
-			class="<?php echo \esc_attr("{$componentClass}__dialog"); ?>"
+			class="<?php echo esc_attr("{$componentClass}__dialog"); ?>"
 			role="dialog"
 			aria-modal="true"
 		>
 			<?php if ($modalExitButton) { ?>
-				<div class="<?php echo \esc_attr("{$componentClass}__close"); ?>">
+				<div class="<?php echo esc_attr("{$componentClass}__close"); ?>">
 					<button
-						<?php echo \esc_attr("data-{$componentJsToggleClass}-close"); ?>
-						class="<?php echo \esc_attr("{$componentClass}__close-button"); ?>"
-						aria-label="<?php echo \esc_attr__('Close modal', 'eightshift-frontend-libs'); ?>"
+						<?php echo esc_attr("data-{$componentJsToggleClass}-close"); ?>
+						class="<?php echo esc_attr("{$componentClass}__close-button"); ?>"
+						aria-label="<?php echo esc_attr__('Close modal', 'eightshift-frontend-libs'); ?>"
 					>
-						<?php echo $manifest['resources']['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo $manifest['resources']['icon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 					</button>
 				</div>
 			<?php } ?>
 
-			<div class="<?php echo \esc_attr("{$componentClass}__content"); ?>">
+			<div class="<?php echo esc_attr("{$componentClass}__content"); ?>">
 				<?php
-					echo $modalContent; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $modalContent; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 				?>
 			</div>
 		</div>

--- a/blocks/init/src/Blocks/components/paragraph/paragraph.php
+++ b/blocks/init/src/Blocks/components/paragraph/paragraph.php
@@ -38,6 +38,6 @@ $paragraphClass = Components::classnames([
 
 <?php echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
-<p class="<?php echo \esc_attr($paragraphClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
-	<?php echo \wp_kses_post($paragraphContent); ?>
+<p class="<?php echo esc_attr($paragraphClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+	<?php echo wp_kses_post($paragraphContent); ?>
 </p>

--- a/blocks/init/src/Blocks/components/quote/quote.php
+++ b/blocks/init/src/Blocks/components/quote/quote.php
@@ -29,14 +29,14 @@ $quoteClass = Components::classnames([
 
 ?>
 
-<figure class="<?php echo \esc_attr($quoteClass); ?>">
-	<i class="<?php echo \esc_attr("{$componentClass}__icon"); ?>">
-		<?php echo $manifest['resources']['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<figure class="<?php echo esc_attr($quoteClass); ?>">
+	<i class="<?php echo esc_attr("{$componentClass}__icon"); ?>">
+		<?php echo $manifest['resources']['icon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 	</i>
 
-	<blockquote class="<?php echo \esc_attr("{$componentClass}__content"); ?>">
+	<blockquote class="<?php echo esc_attr("{$componentClass}__content"); ?>">
 		<?php
-		echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo Components::render(
 			'paragraph',
 			Components::props('heading', $attributes, [
 				'blockClass' => $componentClass
@@ -45,11 +45,11 @@ $quoteClass = Components::classnames([
 		?>
 	</blockquote>
 
-	<div class="<?php echo \esc_attr("{$componentClass}__separator"); ?>"></div>
+	<div class="<?php echo esc_attr("{$componentClass}__separator"); ?>"></div>
 
-	<figcaption class="<?php echo \esc_attr("{$componentClass}__caption"); ?>">
+	<figcaption class="<?php echo esc_attr("{$componentClass}__caption"); ?>">
 		<?php
-		echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo Components::render(
 			'paragraph',
 			Components::props('paragraph', $attributes, [
 				'blockClass' => $componentClass

--- a/blocks/init/src/Blocks/components/scroll-to-top/scroll-to-top.php
+++ b/blocks/init/src/Blocks/components/scroll-to-top/scroll-to-top.php
@@ -29,6 +29,6 @@ $scrollToTopClass = Components::classnames([
 ]);
 ?>
 
-<button class="<?php echo \esc_attr($scrollToTopClass); ?>">
-	<?php echo $manifest['resources']['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+<button class="<?php echo esc_attr($scrollToTopClass); ?>">
+	<?php echo $manifest['resources']['icon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 </button>

--- a/blocks/init/src/Blocks/components/search-bar/search-bar.php
+++ b/blocks/init/src/Blocks/components/search-bar/search-bar.php
@@ -47,24 +47,24 @@ $labelClass = Components::classnames([
 
 <form
 	role="search"
-	method="<?php echo \esc_attr($searchBarMethod); ?>"
-	class="<?php echo \esc_attr($searchClass); ?>"
-	action="<?php echo \esc_url($searchBarAction); ?>"
+	method="<?php echo esc_attr($searchBarMethod); ?>"
+	class="<?php echo esc_attr($searchClass); ?>"
+	action="<?php echo esc_url($searchBarAction); ?>"
 >
 	<label
-		class="<?php echo \esc_attr($labelClass); ?>"
-		for="<?php echo \esc_attr($searchBarId); ?>">
-		<?php echo \esc_html($searchBarLabel); ?>
+		class="<?php echo esc_attr($labelClass); ?>"
+		for="<?php echo esc_attr($searchBarId); ?>">
+		<?php echo esc_html($searchBarLabel); ?>
 	</label>
 	<input
 		type="text"
-		value="<?php echo \get_search_query(); ?>"
+		value="<?php echo get_search_query(); ?>"
 		name="s"
 		<?php if (!empty($searchBarId)) { ?>
-			id="<?php echo \esc_attr($searchBarId); ?>"
+			id="<?php echo esc_attr($searchBarId); ?>"
 		<?php } ?>
-		class="<?php echo \esc_attr($inputClass); ?>"
-		placeholder="<?php echo \esc_attr($searchBarPlaceholder); ?>"
+		class="<?php echo esc_attr($inputClass); ?>"
+		placeholder="<?php echo esc_attr($searchBarPlaceholder); ?>"
 	/>
-	<input type="hidden" name="post_type" value="<?php echo \esc_attr($searchBarPostType); ?>" />
+	<input type="hidden" name="post_type" value="<?php echo esc_attr($searchBarPostType); ?>" />
 </form>

--- a/blocks/init/src/Blocks/components/share/share.php
+++ b/blocks/init/src/Blocks/components/share/share.php
@@ -10,9 +10,9 @@ use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 
 $manifest = Components::getManifest(__DIR__);
 
-$postUrl = $attributes['postUrl'] ?? \get_the_permalink();
-$postTitle = $attributes['postTitle'] ?? \get_the_title();
-$postImageUrl = $attributes['postImageUrl'] ?? \get_the_post_thumbnail_url(\get_the_ID(), 'large') ?? '';
+$postUrl = $attributes['postUrl'] ?? get_the_permalink();
+$postTitle = $attributes['postTitle'] ?? get_the_title();
+$postImageUrl = $attributes['postImageUrl'] ?? get_the_post_thumbnail_url(get_the_ID(), 'large') ?? '';
 
 $socialNetworks = [
 	'twitter' => "https://twitter.com/intent/tweet?url={$postUrl}&text={$postTitle}",
@@ -42,7 +42,7 @@ $shareItemClass = Components::classnames([
 
 $networkNames = array_column($manifest['socialOptions'], 'label', 'value');
 ?>
-<div class="<?php echo \esc_attr($shareClass); ?>">
+<div class="<?php echo esc_attr($shareClass); ?>">
 	<span><?php echo esc_html__('Share on', 'eightshift-frontend-libs'); ?></span>
 
 	<?php

--- a/blocks/init/src/Blocks/components/skip-link/skip-link.php
+++ b/blocks/init/src/Blocks/components/skip-link/skip-link.php
@@ -30,7 +30,7 @@ $skipLinkTarget = Components::checkAttr('skipLinkTarget', $attributes, $manifest
 ?>
 <a
 	href="<?php echo esc_url($skipLinkTarget); ?>"
-	class="<?php echo \esc_attr($skipLinkClasses); ?>"
+	class="<?php echo esc_attr($skipLinkClasses); ?>"
 >
 	<?php echo esc_html__('Skip to main content', 'eightshift-frontend-libs'); ?>
 </a>

--- a/blocks/init/src/Blocks/components/social-links/social-links.php
+++ b/blocks/init/src/Blocks/components/social-links/social-links.php
@@ -29,7 +29,7 @@ $socialLinksClass = Components::classnames([
 ]);
 
 ?>
-<ul class="<?php echo \esc_html($socialLinksClass); ?>">
+<ul class="<?php echo esc_html($socialLinksClass); ?>">
 	<?php
 	if (!is_iterable($socialLinksItems)) {
 		return;
@@ -46,15 +46,15 @@ $socialLinksClass = Components::classnames([
 		}
 
 		?>
-		<li class="<?php echo \esc_html("{$componentClass}__item"); ?>">
+		<li class="<?php echo esc_html("{$componentClass}__item"); ?>">
 			<a
-				class="<?php echo \esc_html("{$componentClass}__link"); ?>"
+				class="<?php echo esc_html("{$componentClass}__link"); ?>"
 				href="<?php echo esc_url($href); ?>"
 				title="<?php echo esc_attr($linkTitle); ?>"
 				target="_blank"
 				rel="noreferrer noopener"
 			>
-				<?php echo $manifest['icons'][$icon]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo $manifest['icons'][$icon]; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 			</a>
 		</li>
 	<?php } ?>

--- a/blocks/init/src/Blocks/components/video/video.php
+++ b/blocks/init/src/Blocks/components/video/video.php
@@ -50,10 +50,10 @@ if (!$videoUrl) {
 ?>
 
 <video
-	class="<?php echo \esc_attr($videoClass); ?>"
-	<?php echo \esc_attr($additionalAttributes); ?>
-	preload="<?php echo \esc_attr($videoPreload); ?>"
-	poster="<?php echo \esc_attr($videoPoster); ?>"
+	class="<?php echo esc_attr($videoClass); ?>"
+	<?php echo esc_attr($additionalAttributes); ?>
+	preload="<?php echo esc_attr($videoPreload); ?>"
+	poster="<?php echo esc_attr($videoPoster); ?>"
 >
 	<?php
 	if (!is_iterable($videoUrl)) {

--- a/blocks/init/src/Blocks/custom/button/button.php
+++ b/blocks/init/src/Blocks/custom/button/button.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/carousel/carousel.php
+++ b/blocks/init/src/Blocks/custom/carousel/carousel.php
@@ -48,19 +48,19 @@ $paginationClass = Components::classnames([
 	data-show-items="<?php echo esc_attr($carouselShowItems); ?>"
 >
 	<div class="<?php echo esc_attr('swiper-wrapper'); ?>">
-		<?php echo $innerBlockContent; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo $innerBlockContent; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 	</div>
 
 	<?php if ($carouselShowPrevNext) { ?>
-		<button class="<?php echo \esc_attr($prevButtonClass); ?>" aria-label="<?php echo esc_attr__('Previous slide', 'eightshift-frontend-libs'); ?>">
-			<?php echo $manifest['resources']['prevIcon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<button class="<?php echo esc_attr($prevButtonClass); ?>" aria-label="<?php echo esc_attr__('Previous slide', 'eightshift-frontend-libs'); ?>">
+			<?php echo $manifest['resources']['prevIcon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 		</button>
-		<button class="<?php echo \esc_attr($nextButtonClass); ?>" aria-label="<?php echo esc_attr__('Next slide', 'eightshift-frontend-libs'); ?>">
-			<?php echo $manifest['resources']['nextIcon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<button class="<?php echo esc_attr($nextButtonClass); ?>" aria-label="<?php echo esc_attr__('Next slide', 'eightshift-frontend-libs'); ?>">
+			<?php echo $manifest['resources']['nextIcon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 		</button>
 	<?php } ?>
 
 	<?php if ($carouselShowPagination) { ?>
-		<div class="<?php echo \esc_attr($paginationClass); ?>"></div>
+		<div class="<?php echo esc_attr($paginationClass); ?>"></div>
 	<?php } ?>
 </div>

--- a/blocks/init/src/Blocks/custom/column/column.php
+++ b/blocks/init/src/Blocks/custom/column/column.php
@@ -16,7 +16,7 @@ $blockClass = $attributes['blockClass'] ?? '';
 $unique = Components::getUnique();
 ?>
 
-<div class="<?php echo \esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique) ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique) ?>">
 	<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest), $innerBlockContent;

--- a/blocks/init/src/Blocks/custom/columns/columns.php
+++ b/blocks/init/src/Blocks/custom/columns/columns.php
@@ -14,7 +14,7 @@ $manifest = Components::getManifest(__DIR__);
 $blockClass = $attributes['blockClass'] ?? '';
 $unique = Components::getUnique();
 ?>
-<div class="<?php echo \esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest), $innerBlockContent;

--- a/blocks/init/src/Blocks/custom/example/example.php
+++ b/blocks/init/src/Blocks/custom/example/example.php
@@ -16,6 +16,6 @@ $exampleContent = Components::checkAttr('exampleContent', $attributes, $manifest
 
 ?>
 
-<div class="<?php echo \esc_attr($blockClass); ?>">
-	<?php echo \wp_kses_post($exampleContent); ?>
+<div class="<?php echo esc_attr($blockClass); ?>">
+	<?php echo wp_kses_post($exampleContent); ?>
 </div>

--- a/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
+++ b/blocks/init/src/Blocks/custom/featured-categories/featured-categories.php
@@ -27,8 +27,8 @@ if (!$taxonomyName) {
 ?>
 
 <ul
-	class="<?php echo \esc_attr($blockClass); ?>"
-	data-id="<?php echo \esc_attr($unique); ?>"
+	class="<?php echo esc_attr($blockClass); ?>"
+	data-id="<?php echo esc_attr($unique); ?>"
 >
 	<?php
 		echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -47,7 +47,7 @@ if (!$taxonomyName) {
 		),
 	];
 
-	$allTerms = \get_terms($args);
+	$allTerms = get_terms($args);
 
 	if (!is_iterable($allTerms)) {
 		return;
@@ -61,7 +61,7 @@ if (!$taxonomyName) {
 			'paragraphContent' => is_object($termObject) ? $termObject->description : '',
 			'paragraphUse' => is_object($termObject),
 			'buttonContent' => __('See posts', 'eightshift-frontend-libs'),
-			'buttonUrl' => \get_term_link($termObject),
+			'buttonUrl' => get_term_link($termObject),
 			'buttonColor' => 'primary',
 			'headingSize' => 'big',
 		];

--- a/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
+++ b/blocks/init/src/Blocks/custom/featured-posts/featured-posts.php
@@ -27,8 +27,8 @@ global $post;
 
 <ul
 	class="<?php echo esc_attr($blockClass); ?>"
-	data-items-per-line=<?php echo \esc_attr($featuredPostsItemsPerLine); ?>
-	data-id="<?php echo \esc_attr($unique); ?>"
+	data-items-per-line=<?php echo esc_attr($featuredPostsItemsPerLine); ?>
+	data-id="<?php echo esc_attr($unique); ?>"
 >
 	<?php
 		echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -75,25 +75,25 @@ global $post;
 			$args['orderby'] = 'post__in';
 		}
 
-		$mainQuery = new \WP_Query($args);
+		$mainQuery = new WP_Query($args);
 
 		if ($mainQuery->have_posts()) {
 			while ($mainQuery->have_posts()) {
 				$mainQuery->the_post();
 
-				$postId = \get_the_ID();
-				$image = \get_the_post_thumbnail_url($postId, 'large');
-				$excerpt = \get_the_excerpt($postId);
+				$postId = get_the_ID();
+				$image = get_the_post_thumbnail_url($postId, 'large');
+				$excerpt = get_the_excerpt($postId);
 
 				$cardProps = [
 					'imageUrl' => $image,
 					'imageUse' => $image ?? true,
 					'introUse' => false,
-					'headingContent' => \get_the_title($postId), // @phpstan-ignore-line
+					'headingContent' => get_the_title($postId), // @phpstan-ignore-line
 					'paragraphContent' => $excerpt,
 					'paragraphUse' => !empty($excerpt),
 					'buttonContent' => __('Read', 'eightshift-frontend-libs'),
-					'buttonUrl' => \get_the_permalink($postId), // @phpstan-ignore-line
+					'buttonUrl' => get_the_permalink($postId), // @phpstan-ignore-line
 					'buttonColor' => 'primary',
 					'headingSize' => 'big',
 				];
@@ -109,7 +109,7 @@ global $post;
 				</li>
 				<?php
 			}
-			\wp_reset_postdata();
+			wp_reset_postdata();
 		}
 		?>
 </ul>

--- a/blocks/init/src/Blocks/custom/group/group.php
+++ b/blocks/init/src/Blocks/custom/group/group.php
@@ -11,5 +11,5 @@ $blockClass = $attributes['blockClass'] ?? '';
 ?>
 
 <div class="<?php echo esc_attr($blockClass); ?>">
-	<?php echo $innerBlockContent; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	<?php echo $innerBlockContent; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 </div>

--- a/blocks/init/src/Blocks/custom/heading/heading.php
+++ b/blocks/init/src/Blocks/custom/heading/heading.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/image/image.php
+++ b/blocks/init/src/Blocks/custom/image/image.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo \esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/lists/lists.php
+++ b/blocks/init/src/Blocks/custom/lists/lists.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/paragraph/paragraph.php
+++ b/blocks/init/src/Blocks/custom/paragraph/paragraph.php
@@ -16,7 +16,7 @@ $blockClass = $attributes['blockClass'] ?? '';
 $unique = Components::getUnique();
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/quote/quote.php
+++ b/blocks/init/src/Blocks/custom/quote/quote.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/custom/video/video.php
+++ b/blocks/init/src/Blocks/custom/video/video.php
@@ -17,7 +17,7 @@ $unique = Components::getUnique();
 
 ?>
 
-<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo \esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($blockClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -23,8 +23,8 @@ $wrapperParentClassItemInnerClass = Components::selector($wrapperParentClass, $w
 if (!$wrapperUse || $wrapperDisable) {
 	if ($wrapperParentClass) {
 		?>
-			<div class="<?php echo \esc_attr($wrapperParentClassItemClass); ?>">
-				<div class="<?php echo \esc_attr($wrapperParentClassItemInnerClass); ?>">
+			<div class="<?php echo esc_attr($wrapperParentClassItemClass); ?>">
+				<div class="<?php echo esc_attr($wrapperParentClassItemInnerClass); ?>">
 		<?php
 	}
 
@@ -92,17 +92,17 @@ $wrapperMainAnchorClass = Components::selector($componentClass, $componentClass,
 $idOutput = '';
 
 if ($wrapperId) {
-	$escapedId = \esc_attr($wrapperId);
+	$escapedId = esc_attr($wrapperId);
 	$idOutput = "id='{$escapedId}'";
 }
 
 ?>
 <div
-	class="<?php echo \esc_attr($wrapperClass); ?>"
-	<?php echo $idOutput; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	class="<?php echo esc_attr($wrapperClass); ?>"
+	<?php echo $idOutput; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 >
 	<?php if ($wrapperAnchorId) { ?>
-		<div class="<?php echo \esc_attr($wrapperMainAnchorClass); ?>" id="<?php echo \esc_attr($wrapperAnchorId); ?>"></div>
+		<div class="<?php echo esc_attr($wrapperMainAnchorClass); ?>" id="<?php echo esc_attr($wrapperAnchorId); ?>"></div>
 	<?php } ?>
 
 	<?php if ($wrapperUseSimple) { ?>
@@ -114,8 +114,8 @@ if ($wrapperId) {
 		);
 		?>
 	<?php } else { ?>
-		<div class="<?php echo \esc_attr($wrapperContainerClass); ?>">
-			<div class="<?php echo \esc_attr($wrapperInnerClass); ?>">
+		<div class="<?php echo esc_attr($wrapperContainerClass); ?>">
+			<div class="<?php echo esc_attr($wrapperInnerClass); ?>">
 				<?php
 				$this->renderWrapperView(
 					$templatePath,


### PR DESCRIPTION
# Description

I ran `composer standards:fix` and replaced `WordPress.Security.EscapeOutput.OutputNotEscaped` ignores with `Eightshift.Security.ComponentsEscape.OutputNotEscaped`.
