### PR TITLE
Fix for option overflow when scrollbars are enabled

### DIFF
--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -375,6 +375,18 @@ body {
 		border-radius: 6px !important;
 	}
 
+	// Fix for scrollbar overflow.
+	@supports (scrollbar-gutter: stable) {
+		.interface-interface-skeleton__sidebar {
+			scrollbar-gutter: stable;
+		}
+	}
+		
+	@supports not (scrollbar-gutter: stable) {
+		.interface-interface-skeleton__sidebar {
+			overflow-x: hidden;
+		}
+	}
 }
 
 @import './es-utility-classes.scss';


### PR DESCRIPTION
# Description

Closes #581.

For some reason when scrollbars are enabled in Firefox and Safari the options panel was overflowing the Gutenberg sidebar element.

`scrollbar-gutter: stable` ([if you wanna learn more](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter)) fixes the problem in Firefox and the sidebar now looks proper, without any overflow.

Unfortunately, Safari doesn't support `scrollbar-gutter` (yet), so I had to resort to simple `overflow-x: hidden`, which means that on the right instead of the empty space there's a scrollbar, but nothing is clipped by it (and there is no more horizontal scroll).

# Screenshots / Videos

\-

# Linked documentation PR

\-
