### PR TITLE
Text helpers fixes and tests

### DIFF
--- a/scripts/helpers/text-helpers.js
+++ b/scripts/helpers/text-helpers.js
@@ -26,7 +26,7 @@ export const truncateMiddle = (input, maxLength, separator = '...') => {
 	
 	  // Return error if separator would prevent any characters from the word showing.
 	  if (separator.length + 1 > maxLength) {
-		return new Error('Separator length exceeds the passed maximum length, string wouldn\'t be visible.');
+		throw new Error('Separator length exceeds the passed maximum length, string wouldn\'t be visible.');
 	  }
 	
 	  // Smartly split up the string.

--- a/scripts/helpers/text-helpers.js
+++ b/scripts/helpers/text-helpers.js
@@ -2,8 +2,8 @@
  * Slices the string in the middle and inputs the provided separator so that the string is maxLength characters long.
  *
  * @param {string} input             - String to slice.
- * @param {number} maxLength         - Maximum allowed string length. Should be at least 8.
- * @param {string} [separator='...'] - Separator to insert. Should be exactly three characters long.
+ * @param {number} maxLength         - Maximum allowed string length.
+ * @param {string} [separator='...'] - Separator to insert.
  *
  * @access public
  *

--- a/scripts/helpers/text-helpers.js
+++ b/scripts/helpers/text-helpers.js
@@ -58,6 +58,7 @@ export const truncateMiddle = (input, maxLength, separator = '...') => {
  * Output:
  * ```js
  * Test&Up
+ * ```
  */
 export const unescapeHTML = (input) =>
 	input.replace(

--- a/scripts/helpers/text-helpers.js
+++ b/scripts/helpers/text-helpers.js
@@ -16,14 +16,29 @@
  *
  * Output:
  * ```js
- * "https://eig...contact/"
+ * "https://ei.../contact/"
  */
 export const truncateMiddle = (input, maxLength, separator = '...') => {
-	if (input?.length <= maxLength) {
+	 // If the string is shorter than maxLength, just return it.
+	 if (input?.length <= maxLength) {
 		return input;
-	}
-
-	return `${input.slice(0, maxLength / 2)}${separator}${input.slice(-1 * (maxLength / 2 - 3))}`;
+	  }
+	
+	  // Return error if separator would prevent any characters from the word showing.
+	  if (separator.length + 1 > maxLength) {
+		return new Error('Separator length exceeds the passed maximum length, string wouldn\'t be visible.');
+	  }
+	
+	  // Smartly split up the string.
+	  const maxStringLength = maxLength - separator.length;
+	
+	  const leftPartLength = Math.ceil(maxStringLength / 2);
+	  const rightPartLength = Math.floor(maxStringLength / 2);
+	
+	  const leftPart = input.slice(0, leftPartLength).trim();
+	  const rightPart = rightPartLength > 0 ? input.slice(-1 * rightPartLength).trim() : '';
+	
+	  return `${leftPart}${separator}${rightPart}`;
 };
 
 /**

--- a/scripts/helpers/text-helpers.js
+++ b/scripts/helpers/text-helpers.js
@@ -7,7 +7,7 @@
  *
  * @access public
  *
- * @returns {string} Truncated string.
+ * @returns {string|Error} Truncated string or error if separator length exceeds maxLength.
  *
  * Usage:
  * ```js

--- a/tests/unit/scripts/helpers/text-helpers.test.js
+++ b/tests/unit/scripts/helpers/text-helpers.test.js
@@ -1,0 +1,21 @@
+import { truncateMiddle, unescapeHTML } from "../../../../scripts/helpers";
+
+test.each([
+	{ inputString: 'Lorem ipsum dolor sit amet.', maxLength: 8, expected: 'Lor...t.' },
+	{ inputString: 'Lorem', maxLength: 8, expected: 'Lorem' },
+	{ inputString: 'Lorem ipsum dolor', maxLength: 10, inputSeparator: ':', expected: 'Lorem:olor' },
+	{ inputString: 'Lorem ipsum dolor sit amet.', inputSeparator: '........', maxLength: 8, shouldError: true },
+])('tests hextToRgb returns a valid value %s', ({ inputString, maxLength, inputSeparator, expected, shouldError = false }) => {
+	if (shouldError) {
+		expect(() => truncateMiddle(inputString, maxLength, inputSeparator)).toThrow();
+	} else {
+		expect(truncateMiddle(inputString, maxLength, inputSeparator)).toBe(expected);
+	}
+});
+
+test.each([
+	{ input: 'Test string.', expected: 'Test string.' },
+	{ input: 'Test&#38;string', expected: 'Test&string' },
+])('tests hextToRgb returns a valid value %s', ({ input, expected }) => {
+	expect(unescapeHTML(input)).toBe(expected);
+});


### PR DESCRIPTION
# Description

Closes #422.

Helper is now (a bit) smarter about the passed separator length. Also now throws an `Error` if separator length would occlude the truncate string completely.

# Screenshots / Videos

\-

# Linked documentation PR

\-
