### PR TITLE
Clean changelog and versions that start from 1.0.0

### DIFF
--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -17,6 +17,7 @@ const {
   misc: { log, variable },
 } = require('../basics');
 const { searchReplace } = require('../search-replace');
+const { replaceVersionNumbers } = require('../replace-version-numbers');
 const { cleanup } = require('../cleanup');
 const { scriptArguments } = require('../arguments');
 const { installModifiedNodeDependencies, installModifiedComposerDependencies } = require('../dependencies');
@@ -79,6 +80,12 @@ exports.handler = async (argv) => {
   await installStep({
     describe: `${step}. Cleaning up`,
     thisHappens: cleanup(projectPath),
+  });
+  step++;
+
+  await installStep({
+    describe: `${step}. Replacing version numbers`,
+    thisHappens: replaceVersionNumbers(projectPath),
   });
   step++;
 

--- a/setup/create-wp-project/src/commands/theme.js
+++ b/setup/create-wp-project/src/commands/theme.js
@@ -85,7 +85,7 @@ exports.handler = async (argv) => {
 
   await installStep({
     describe: `${step}. Replacing version numbers`,
-    thisHappens: replaceVersionNumbers(projectPath),
+    thisHappens: replaceVersionNumbers(projectPath, promptedInfo.projectName),
   });
   step++;
 

--- a/setup/create-wp-project/src/replace-version-numbers.js
+++ b/setup/create-wp-project/src/replace-version-numbers.js
@@ -1,0 +1,22 @@
+
+const replace = require('replace-in-file');
+const path = require('path');
+const fs = require('fs-extra');
+
+const replaceVersionNumbers = async(projectPath) => {
+  const pathStyleCss = path.join(projectPath, 'style.css');
+
+  // style.css
+  if (await fs.pathExists(pathStyleCss)) {
+    await replace({
+      files: pathStyleCss,
+      from: /^Version: .*$/m,
+      to: 'Version: 1.0.0',
+    });
+  }
+
+};
+
+module.exports = {
+  replaceVersionNumbers,
+};

--- a/setup/create-wp-project/src/replace-version-numbers.js
+++ b/setup/create-wp-project/src/replace-version-numbers.js
@@ -3,20 +3,71 @@ const replace = require('replace-in-file');
 const path = require('path');
 const fs = require('fs-extra');
 
-const replaceVersionNumbers = async(projectPath) => {
-  const pathStyleCss = path.join(projectPath, 'style.css');
+const replaceVersionNumbers = async (projectPath, themeName) => {
+	const styleCssPath = path.join(projectPath, 'style.css');
+	const functionsPhpPath = path.join(projectPath, 'functions.php');
+	const packageLockPath = path.join(projectPath, 'package-lock.json');
+	const packageJsonPath = path.join(projectPath, 'package.json');
+	const changelogPath = path.join(projectPath, 'CHANGELOG.md');
 
-  // style.css
-  if (await fs.pathExists(pathStyleCss)) {
-    await replace({
-      files: pathStyleCss,
-      from: /^Version: .*$/m,
-      to: 'Version: 1.0.0',
-    });
-  }
+	// style.css
+	if (await fs.pathExists(styleCssPath)) {
+		await replace({
+			files: styleCssPath,
+			from: /^Version: .*$/m,
+			to:    'Version: 1.0.0',
+		});
+	}
 
+	// functions.php
+	if (await fs.pathExists(functionsPhpPath)) {
+		await replace({
+			files: functionsPhpPath,
+			from: /^ \* Version: .*$/m,
+			to: ' * Version: 1.0.0',
+		});
+	}
+
+	// package-lock.json
+	if (await fs.pathExists(packageLockPath)) {
+		await replace({
+			files: packageLockPath,
+			from: /^\t"version": ".*",$/m,
+			to: `\t"version": "1.0.0",\n`,
+		});
+	}
+
+	// package.json
+	if (await fs.pathExists(packageJsonPath)) {
+		await replace({
+			files: packageJsonPath,
+			from: /^\t"version": ".*",$/m,
+			to: `\t"version": "1.0.0",\n`,
+		});
+	}
+
+	// CHANGELOG.md
+	if (await fs.pathExists(changelogPath)) {
+		const newChangelog = [
+			`# Changelog for the ${themeName}`,
+			'All notable changes to this project will be documented in this file.\n',
+			'This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).\n',
+			'## [Unreleased] - TBD\n',
+			'### Added\n',
+			'### Changed\n',
+			'### Deprecated\n',
+			'### Removed\n',
+			'### Fixed\n',
+			'## [1.0.0] - <setup-date>\n',
+			'Initial tagged release.\n',
+			'[Unreleased]: https://github.com/infinum/eightshift-boilerplate/compare/master...HEAD\n\n',
+			'[1.0.0]: https://github.com/infinum/eightshift-boilerplate/compare/INIT_COMMIT...1.0.0`',
+		].join('\n');
+
+		await fs.writeFile(changelogPath, newChangelog, 'utf-8');
+	}
 };
 
 module.exports = {
-  replaceVersionNumbers,
+	replaceVersionNumbers,
 };


### PR DESCRIPTION
# Description

Closes #550.

As per the issue, in these files:
- `style.css`
- `functions.php`
- `package-lock.json`
- `package.json`
the version is set to '1.0.0' instead of whatever was pulled from boilerplate.

Also, `CHANGELOG.md` now gets replaced with a blank template.

# Screenshots / Videos

\-

# Linked documentation PR

\-
