### PR TITLE
A11y improvements after a11y review

### DIFF
--- a/blocks/init/src/Blocks/components/accordion/accordion.php
+++ b/blocks/init/src/Blocks/components/accordion/accordion.php
@@ -65,9 +65,9 @@ $uniqueAccordionTriggerId = Components::getUnique();
 		id="<?php echo esc_attr($uniqueAccordionTriggerId); ?>"
 	>
 		<?php echo esc_html($accordionTitle); ?>
-		<div class="<?php echo esc_attr($accordionIconClass); ?>" aria-hidden="true" >
+		<span class="<?php echo esc_attr($accordionIconClass); ?>" aria-hidden="true" >
 			<?php echo $manifest['resources']['icon']; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
-		</div>
+		</span>
 	</button>
 
 	<div

--- a/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
+++ b/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
@@ -34,7 +34,7 @@ $jumbotronContentWrapClass = Components::selector($componentClass, $componentCla
 
 ?>
 
-<div class="<?php echo esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>">
+<div class="<?php echo esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>" role="section">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/blocks/init/src/Blocks/components/lists/components/lists-options.js
+++ b/blocks/init/src/Blocks/components/lists/components/lists-options.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { ColorPaletteCustom, icons, getOption, checkAttr, getAttrKey, ComponentUseToggle, IconLabel, CustomSelect, IconToggle, BlockIcon, SimpleVerticalSingleSelect } from '@eightshift/frontend-libs/scripts';
+import { ColorPaletteCustom, icons, getOption, checkAttr, getAttrKey, ComponentUseToggle, IconLabel, CustomSelect, IconToggle, BlockIcon, SimpleHorizontalSingleSelect } from '@eightshift/frontend-libs/scripts';
 import manifest from '../manifest.json';
 
 export const ListsOptions = (attributes) => {
@@ -65,14 +65,11 @@ export const ListsOptions = (attributes) => {
 					}
 
 					{showListsOrdered &&
-						<SimpleVerticalSingleSelect
+						<SimpleHorizontalSingleSelect
 							label={__('List type', 'eightshift-frontend-libs')}
 							value={listsOrdered}
 							options={getOption('listsOrdered', attributes, manifest)}
 							onChange={(value) => setAttributes({ [getAttrKey('listsOrdered', attributes, manifest)]: value })}
-							isClearable={false}
-							isSearchable={false}
-							simpleValue
 						/>
 					}
 				

--- a/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
+++ b/blocks/init/src/Blocks/components/menu/styles/horizontal/menu-horizontal-style.scss
@@ -2,10 +2,12 @@ $menu-horizontal: (
 	link-modifiers: (
 		normal: (
 			color: global-settings(colors, black),
+			text-decoration-color: rgba(global-settings(colors, black), 0.15),
 		),
 		hover: (
 			color: global-settings(colors, primary),
-		)
+			text-decoration-color: rgba(global-settings(colors, primary), 1),
+		),
 	),
 );
 
@@ -19,14 +21,23 @@ $menu-horizontal: (
 	gap: 0.75rem;
 
 	&__link {
-		text-decoration: none;
+		text-decoration: underline;
+		text-decoration-color: map-get-deep($menu-horizontal, link-modifiers, normal, text-decoration-color);
 		height: 100%;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		transition: 0.3s color ease-in-out;
+		transition: color 0.3s, text-decoration-color 0.3s ease-in-out;
 		overflow-wrap: anywhere;
 
 		@include link($menu-horizontal, link-modifiers);
+
+		&:hover {
+			text-decoration-color: map-get-deep($menu-horizontal, link-modifiers, hover, text-decoration-color);
+		}
+
+		@media (prefers-contrast: more) {
+			text-decoration-color: map-get-deep($menu-horizontal, link-modifiers, hover, text-decoration-color);
+		}
 	}
 }

--- a/blocks/init/src/Blocks/components/menu/styles/vertical/menu-vertical-style.scss
+++ b/blocks/init/src/Blocks/components/menu/styles/vertical/menu-vertical-style.scss
@@ -3,9 +3,12 @@ $menu-vertical: (
 	link-modifiers: (
 		normal: (
 			color: global-settings(colors, black),
+			text-decoration-color: rgba(global-settings(colors, black), 0.15),
 		),
 		hover: (
 			color: global-settings(colors, primary),
+			text-decoration-color: rgba(global-settings(colors, primary), 1),
+
 		),
 	),
 );
@@ -15,11 +18,20 @@ $menu-vertical: (
 
 	&__link {
 		display: block;
-		text-decoration: none;
+		text-decoration: underline;
+		text-decoration-color: map-get-deep($menu-vertical, link-modifiers, normal, text-decoration-color);
 		transition: 0.3s color ease-in-out;
 		padding: map-get-strict($menu-vertical, link-padding);
 		overflow-wrap: anywhere;
 
 		@include link($menu-vertical, link-modifiers);
+
+		&:hover {
+			text-decoration-color: map-get-deep($menu-horizontal, link-modifiers, hover, text-decoration-color);
+		}
+
+		@media (prefers-contrast: more) {
+			text-decoration-color: map-get-deep($menu-horizontal, link-modifiers, hover, text-decoration-color);
+		}
 	}
 }

--- a/blocks/init/src/Blocks/components/video/components/video-options.js
+++ b/blocks/init/src/Blocks/components/video/components/video-options.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { MediaPlaceholder } from '@wordpress/block-editor';
-import { Button, BaseControl, Placeholder, ExternalLink, TextControl } from '@wordpress/components';
+import { Button, BaseControl, Placeholder, ExternalLink, TextControl, Notice } from '@wordpress/components';
 import { getOption, checkAttr, getAttrKey, IconLabel, icons, Collapsable, ComponentUseToggle, IconToggle, SimpleVerticalSingleSelect, FancyDivider, CustomSelect, CustomSelectCustomOption, CustomSelectCustomValueDisplay } from '@eightshift/frontend-libs/scripts';
 import manifest from '../manifest.json';
 
@@ -261,6 +261,16 @@ export const VideoOptions = (attributes) => {
 							checked={videoMuted}
 							onChange={(value) => setAttributes({ [getAttrKey('videoMuted', attributes, manifest)]: value })}
 						/>
+					}
+
+
+					{videoAutoplay && !videoMuted && !videoControls &&
+						<Notice 
+							status="warning"
+							isDismissible={false}
+						>
+							{__('This video autoplays with sound and without controls. Reconsider these choices, as they present a challenge to disabled users, cause frustration for all users and might be a violation of WCAG.', 'eightshift-frontend-libs')}
+						</Notice>
 					}
 
 					{showVideoPreload && <br />}

--- a/blocks/init/src/Blocks/components/video/video.php
+++ b/blocks/init/src/Blocks/components/video/video.php
@@ -29,6 +29,7 @@ $videoAutoplay = Components::checkAttr('videoAutoplay', $attributes, $manifest);
 $videoControls = Components::checkAttr('videoControls', $attributes, $manifest);
 $videoMuted = Components::checkAttr('videoMuted', $attributes, $manifest);
 $videoPreload = Components::checkAttr('videoPreload', $attributes, $manifest);
+$videoSubtitleTracks = Components::checkAttr('videoSubtitleTracks', $attributes, $manifest) ?? [];
 
 $videoClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
@@ -54,6 +55,9 @@ if (!$videoUrl) {
 	<?php echo esc_attr($additionalAttributes); ?>
 	preload="<?php echo esc_attr($videoPreload); ?>"
 	poster="<?php echo esc_attr($videoPoster); ?>"
+	<?php if ($videoPoster) { ?>
+		poster="<?php echo esc_attr($videoPoster); ?>"
+	<?php } ?>
 >
 	<?php
 	if (!is_iterable($videoUrl)) {
@@ -68,5 +72,21 @@ if (!$videoUrl) {
 		if ($url && $mime) { ?>
 			<source src="<?php echo esc_url($url); ?>" type="<?php echo esc_attr($mime); ?>" />
 		<?php } ?>
+	<?php } ?>
+
+	<?php foreach ($videoSubtitleTracks as $track) {
+		if (!($track['src'] ?? '') || !($track['kind'] ?? '') || !($track['label'])) {
+			continue;
+		}
+		?>
+		
+		<track 
+			src="<?php echo esc_url($track['src']); ?>"
+			kind="<?php echo esc_attr($track['kind']); ?>"
+			label="<?php echo esc_attr($track['label']); ?>"
+			<?php if ($track['srclang']) { ?>
+				srclang="<?php echo esc_attr($track['srclang']); ?>"
+			<?php } ?>
+		>		
 	<?php } ?>
 </video>


### PR DESCRIPTION
# Description

This PR:
* changes the accordion icon's containing element from `div` to `span`, as `div` is not an allowed child of `button`
* adds `role="section"` to jumbotron container
* replaces SimpleVerticalSingleSelect with SimpleHorizontalSingleSelect in list component's options, a misconfiguration of which caused the list order attribute change to fail 🙈 
* adds CSS to distinguish menu links from other text on the page using underlines
  * see screenshots below
  * includes `prefers-contrast` rules
  * this simply extends the current menu styles, but we should consider rewriting the menu component to be more in line with current practices and new development kit versions
* warns users that it may be a bad idea to set a video as autoplaying, with sound, and without controls
* actually renders `<track>` elements in the video component, which I somehow forgot to commit in the captions PR 🙈 

Merging this will close #491, and will resolve all currently known subtasks in #596 (but I'll wait until we completely finish the a11y review to close it)

# Screenshots / Videos

## Menu
**Default state**
![Screenshot 2022-03-30 at 16 03 39](https://user-images.githubusercontent.com/1742806/160853553-d73cdf62-e456-45cb-8417-0273bd1bd121.png)
**Hover state**
![Screenshot 2022-03-30 at 16 03 46](https://user-images.githubusercontent.com/1742806/160853652-f8927fad-1ff6-422e-aae1-850096528121.png)
**Default state with increased contrast**
![Screenshot 2022-03-30 at 16 04 10](https://user-images.githubusercontent.com/1742806/160853718-0a56b706-857d-4800-85b8-f8344463623f.png)

## Video notice
![Screenshot 2022-03-30 at 16 06 42](https://user-images.githubusercontent.com/1742806/160854187-b8e335fa-543b-47c5-87cb-c7a575754577.png)

