### PR TITLE
Replace role="section" with role="region"

### DIFF
--- a/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
+++ b/blocks/init/src/Blocks/components/jumbotron/jumbotron.php
@@ -34,7 +34,7 @@ $jumbotronContentWrapClass = Components::selector($componentClass, $componentCla
 
 ?>
 
-<div class="<?php echo esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>" role="section">
+<div class="<?php echo esc_attr($jumbotronClass); ?>" data-id="<?php echo esc_attr($unique); ?>" role="region">
 	<?php
 	echo Components::outputCssVariables($attributes, $manifest, $unique, $globalManifest); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 


### PR DESCRIPTION
# Description

In my previous PR, I added `role="section"` to the Jumbotron container, which is an abstract role and the HTML Living Standard considers it incorrect. I've replaced it with `role="region"` in this PR. Sorry.

