### PR TITLE
Adds media-breakpoints variable that pulls variables from global manifest.json

### DIFF
--- a/blocks/init/assets/styles/parts/utils/_shared-variables.scss
+++ b/blocks/init/assets/styles/parts/utils/_shared-variables.scss
@@ -8,6 +8,13 @@ https://github.com/infinum/eightshift-frontend-libs/blob/develop/styles/scss/_co
 
 $base-col-number: global-settings(maxCols);
 
+$media-breakpoints: (
+    mobile: 0 global-settings(breakpoints, mobile),
+    tablet: (global-settings(breakpoints, mobile) + 1) global-settings(breakpoints, tablet),
+    desktop: (global-settings(breakpoints, tablet) + 1) global-settings(breakpoints, desktop),
+    large: (global-settings(breakpoints, desktop) + 1)
+);
+
 :root {
 	--base-font-size: 0.625;
 


### PR DESCRIPTION
# Description

Added variable $media-breakpoints to _shared-variables.scss

$media-breakpoints is defined in node_modules>media-blender with !default keyword which means if there is no variable defined, use these values.
I had to reassign that variable in eightshift-frontend-libs and pull data from blocks manifest.json with global-settings function.
