### PR TITLE
Fix a bug in Safari for hamburger animations

### DIFF
--- a/blocks/init/src/Blocks/components/hamburger/hamburger-style.scss
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger-style.scss
@@ -28,11 +28,11 @@
 			}
 
 			&--top {
-				transform: translate3d(0, -2%, 0);
+				transform: rotate(0) translate3d(0, -2%, 0) scale3d(1, 1, 1);
 			}
 
 			&--btm {
-				transform: translate3d(0, 2%, 0);
+				transform: rotate(0) translate3d(0, 2%, 0) scale3d(1, 1, 1);
 			}
 		}
 	}
@@ -56,7 +56,7 @@
 			transition: {
 				property: transform;
 				duration: 0.3s;
-				timing: ease-out;
+				timing-function: ease-out;
 			}
 		}
 
@@ -64,7 +64,7 @@
 			transition: {
 				property: transform, opacity;
 				duration: 0.3s;
-				timing: ease-out;
+				timing-function: ease-out;
 			}
 		}
 
@@ -83,7 +83,7 @@
 	&.is-menu-open {
 		#{$this}__icon {
 			&--top {
-				transform: rotate(45deg) translate3d(0, 20%, 0);
+				transform: rotate(45deg) translate3d(0, 20%, 0) scale3d(1, 1, 1);
 			}
 
 			&--mid {
@@ -91,7 +91,7 @@
 			}
 
 			&--btm {
-				transform: rotate(-45deg) translate3d(0, -20%, 0);
+				transform: rotate(-45deg) translate3d(0, -20%, 0) scale3d(1, 1, 1);
 			}
 		}
 


### PR DESCRIPTION
# Description

Fix a bug in Safari which causes a glitch in hamburger from default to active state (`is-menu-open`) animation.

# Screenshots / Videos

This is how it looks like in Safari and iOS without the fix:
https://user-images.githubusercontent.com/22823970/169843183-a9275d77-5996-48e1-9fff-9828c43605eb.mov
