### PR TITLE
Webpack 5 - seperate Normalize import from main index.scss

### DIFF
--- a/blocks/init/src/Blocks/assets/styles/application-blocks-editor.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks-editor.scss
@@ -10,6 +10,7 @@
 
 // Globals.
 @import './../../../../assets/styles/parts/shared';
+@import '@eightshift/frontend-libs/styles/scss/normalize';
 
 // Editor styles overrides.
 @import './editor/editor';

--- a/blocks/init/src/Blocks/assets/styles/application-blocks-frontend.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks-frontend.scss
@@ -10,6 +10,7 @@
 
 // Globals.
 @import './../../../../assets/styles/parts/shared';
+@import '@eightshift/frontend-libs/styles/scss/normalize';
 
 // Register frontend specific styles.
 @import './../../frontend/frontend.scss';

--- a/blocks/init/src/Blocks/assets/styles/application-blocks.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks.scss
@@ -10,6 +10,7 @@
 
 // Globals.
 @import './../../../../assets/styles/parts/shared';
+@import '@eightshift/frontend-libs/styles/scss/normalize';
 
 // Register Wrapper block styles.
 @import './../../wrapper/wrapper-style.scss';

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,6 +1,3 @@
-// Normalize.
-@import 'scss/normalize';
-
 // Config.
 @import 'scss/colors';
 


### PR DESCRIPTION
# Description

Changes:
- "normalize" import is not in the main import to prevent normalize "leaking" into the admin
- added all changes from the develop branch

# Screenshots / Videos

\-

# Linked documentation PR

\-
