### PR TITLE
Remove unnecessary escaping in carousel template file

### DIFF
--- a/blocks/init/src/Blocks/custom/carousel/carousel.php
+++ b/blocks/init/src/Blocks/custom/carousel/carousel.php
@@ -47,7 +47,7 @@ $paginationClass = Components::classnames([
 	data-swiper-loop="<?php echo esc_attr($carouselIsLoop ? 'true' : 'false'); ?>"
 	data-show-items="<?php echo esc_attr($carouselShowItems); ?>"
 >
-	<div class="<?php echo esc_attr('swiper-wrapper'); ?>">
+	<div class="swiper-wrapper">
 		<?php echo $innerBlockContent; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
 	</div>
 


### PR DESCRIPTION
The carousel template file had an escaped string, which makes no sense to have. It's a string, so it needs no escaping or echoing using PHP.