### PR TITLE
SASS map output fix if comma in value

### DIFF
--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -89,11 +89,25 @@ function convertJsonToSassMap(data) {
 			continue;
 		}
 
-		output += `${key}: ${value},`;
+		output += `${key}: ${escapeSassMapComma(value)},`;
 	}
 
 	return output;
 }
+
+/**
+ * Adds parentheses around the output if the value contains a comma.
+ *
+ * @param {any} input Input value.
+ * @returns Input value with parentheses around the value if needed.
+ */
+function escapeSassMapComma(input) {
+	if (typeof input === 'string' && input?.includes(',')) {
+		return `(${input})`;
+	}
+
+	return input;
+};
 
 /**
  * Convert Recursive map object data to Sass map variables for inner objects.
@@ -107,20 +121,20 @@ function convertJsonToSassMapInner(data, key) {
 	for (const [innerKey, innerValue] of Object.entries(data)) {
 		switch (key) {
 			case 'colors':
-				output += `${innerValue['slug']}: ${innerValue['color']},`;
+				output += `${innerValue['slug']}: ${escapeSassMapComma(innerValue['color'])},`;
 				break;
 			case 'gradients':
-				output += `${innerValue['slug']}: ${innerValue['gradient']},`;
+				output += `${innerValue['slug']}: ${escapeSassMapComma(innerValue['gradient'])},`;
 				break;
 			case 'fontSizes':
-				output += `${innerKey}: ${innerValue['slug']},`;
+				output += `${innerKey}: ${escapeSassMapComma(innerValue['slug'])},`;
 				break;
 			default:
 				if (Array.isArray(data)) {
 					return output;
 				}
 
-				output += `${innerKey}: ${innerValue},`;
+				output += `${innerKey}: ${escapeSassMapComma(innerValue)},`;
 				break;
 		}
 	}

--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -107,7 +107,7 @@ function escapeSassMapComma(input) {
 	}
 
 	return input;
-};
+}
 
 /**
  * Convert Recursive map object data to Sass map variables for inner objects.


### PR DESCRIPTION
# Description

If the value in global manifest contained a comma, the build would error out because the commas output in SASS maps would confuse it. Though, if you add `''` or `()` around your value the CSS variable output wouldn't be right.

This PR fixes this by adding `()` around the value (just in SASS) if it's a string value and contains a comma.

# Screenshots / Videos

\-

# Linked documentation PR

\-