### PR TITLE
Fix double import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,13 @@
 	},
 	"require": {
 		"php": "^7.4 || <8.0",
-		"ext-json": "*",
-		"php-di/php-di": "^6.3.2"
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"infinum/eightshift-coding-standards": "^1.6",
 		"infinum/eightshift-libs-stubs": "^0.7.0",
-		"php-stubs/wordpress-stubs": "^5.9",
+		"php-stubs/wordpress-stubs": "^6.0",
 		"szepeviktor/phpstan-wordpress": "^1.0.3"
 	},
 	"minimum-stability": "dev",

--- a/scripts/components/advanced-color-picker/advanced-color-picker.js
+++ b/scripts/components/advanced-color-picker/advanced-color-picker.js
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from 'react';
-import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { BaseControl, ColorPicker, GradientPicker, __experimentalGradientPicker as GradientPickerOld } from '@wordpress/components';
+import { Button, Popover, BaseControl, ColorPicker, GradientPicker, __experimentalGradientPicker as GradientPickerOld } from '@wordpress/components';
 import { ColorPaletteCustom, icons, IconLabel } from '../../../scripts';
 import { SimpleHorizontalSingleSelect } from '@eightshift/frontend-libs/scripts/components/simple-horizontal-single-select/simple-horizontal-single-select';
 import { ColorPaletteCustomLayout } from '@eightshift/frontend-libs/scripts/components/color-palette-custom/color-palette-custom';


### PR DESCRIPTION
Fixed the double import of `@wordpress/components` statement in the advanced color picker component
