### PR TITLE
Update imports of normalize stylesheet

### DIFF
--- a/blocks/init/src/Blocks/assets/styles/application-blocks-editor.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks-editor.scss
@@ -10,7 +10,6 @@
 
 // Globals.
 @import './../../../../assets/styles/parts/shared';
-@import '@eightshift/frontend-libs/styles/scss/normalize';
 
 // Editor styles overrides.
 @import './editor/editor';

--- a/blocks/init/src/Blocks/assets/styles/application-blocks-frontend.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks-frontend.scss
@@ -10,7 +10,6 @@
 
 // Globals.
 @import './../../../../assets/styles/parts/shared';
-@import '@eightshift/frontend-libs/styles/scss/normalize';
 
 // Register Wrapper block styles.
 @import './../../wrapper/wrapper-frontend';

--- a/blocks/init/src/Blocks/assets/styles/application-blocks.scss
+++ b/blocks/init/src/Blocks/assets/styles/application-blocks.scss
@@ -9,8 +9,8 @@
  */
 
 // Globals.
-@import './../../../../assets/styles/parts/shared';
 @import '@eightshift/frontend-libs/styles/scss/normalize';
+@import './../../../../assets/styles/parts/shared';
 
 // Register Wrapper block styles.
 @import './../../wrapper/wrapper-style';


### PR DESCRIPTION
Removed import of normalize stylesheet from applicationBlocksFrontned and applicationBlocksEditor stylesheets since it was already imported in applicationBlocks.

Changed the order of the import and moved the normalize script as first.

Multiple imports of normalize script were overriding the font-family declaration in the theme.