### PR TITLE
Fix the button attribute value concatenation

### DIFF
--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -71,7 +71,7 @@ $buttonTag = $buttonUrl ? 'a' : 'button';
 	<?php
 	foreach ($buttonAttrs as $key => $value) {
 		if (!empty($key) && !empty($value)) {
-			echo wp_kses_post("{$key}=" . $value . " ");
+			echo wp_kses_post("{$key}=\"$value\"");
 		}
 	}
 	?>


### PR DESCRIPTION
# Description

As it is currently implemented, the escaped value for the button attributes would break the `title` attribute of the button component.

For instance, if the content of the button had multiple words, like

```
Back to the home page
```

the attribute would be rendered as

```html
<button class="btn" title="Back" to="" the="" home="" page="" data-id="35459615a50e5e94f67bcc626250b58f" href="https://example.test/">
	<i class="icon btn__icon" data-id="5f6e3cc5c768d537cbfac74637bd08f6">
		<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.283 5 21 12l-6.717 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"></path><path stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M19.733 12.032H4" fill="none"></path></svg>
	</i>
	<span>Back to the home page</span>
</button>
```

Which is not correct. The fix will ammend this so that the rendered attribute is now

```html
<button class="btn" title="Back to the home page" data-id="35459615a50e5e94f67bcc626250b58f" href="https://example.test/">
	<i class="icon btn__icon" data-id="5f6e3cc5c768d537cbfac74637bd08f6">
		<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.283 5 21 12l-6.717 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"></path><path stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M19.733 12.032H4" fill="none"></path></svg>
	</i>
	<span>Back to the home page</span>
</button>
```