### PR TITLE
Fix Lists component : identical variable names

### DIFF
--- a/blocks/init/src/Blocks/components/lists/lists.php
+++ b/blocks/init/src/Blocks/components/lists/lists.php
@@ -26,9 +26,9 @@ $selectorClass = $attributes['selectorClass'] ?? $componentClass;
 $listsContent = Components::checkAttr('listsContent', $attributes, $manifest);
 $listsType = Components::checkAttr('listsOrdered', $attributes, $manifest);
 
-$listsType = array_map(static fn($option) => $option['value'], $manifest['options']['listsOrdered'] ?? []); // @phpstan-ignore-line
+$listsTypeOptions = array_map(static fn($option) => $option['value'], $manifest['options']['listsOrdered'] ?? []); // @phpstan-ignore-line
 
-if (!in_array($listsType, $listsType, true)) {
+if (!in_array($listsType, $listsTypeOptions, true)) {
 	return;
 }
 


### PR DESCRIPTION
# Description

Variable for "list type options" and "lists type" have the same name causing premature return.
Updated the variable name for viable lists options to differentiate from the list type variable name.