### PR TITLE
Navbar/footer blocks

### DIFF
--- a/blocks/init/assets/styles/parts/_core.scss
+++ b/blocks/init/assets/styles/parts/_core.scss
@@ -18,3 +18,9 @@ body {
 	position: relative;
 	overflow-x: hidden;
 }
+
+// Fix WP admin bar positioning.
+// stylelint-disable-next-line selector-max-specificity
+#wpadminbar {
+	position: fixed;
+}

--- a/blocks/init/src/Blocks/components/drawer/assets/drawer.js
+++ b/blocks/init/src/Blocks/components/drawer/assets/drawer.js
@@ -1,5 +1,3 @@
-import { debounce } from '@eightshift/frontend-libs/scripts/helpers/debounce';
-
 export class Drawer {
 	constructor({ drawerElement }) {
 		this.drawerElement = drawerElement;
@@ -11,42 +9,62 @@ export class Drawer {
 		if (triggerSelector) {
 			this.trigger = document.querySelector(`.${triggerSelector}`);
 		}
-	}
-	
-	preventScroll() {
-		document.body.classList.add(this.CLASS_NO_SCROLL);
-	}
-	
-	enableScroll() {
-		document.body.classList.remove(this.CLASS_NO_SCROLL);
-	}
-	
-	openMobileMenu() {
-		this.trigger?.classList.add(this.CLASS_MENU_OPEN);
-		this.drawerElement.style.display = 'block';
 
-		const addClass = debounce(() => document.body.classList.add(this.CLASS_MENU_OPEN), 300);
-		addClass();
-
-		this.preventScroll();
+		this.supportsHasSelector = CSS.supports('selector(:has(*))');
 	}
-	
-	closeMobileMenu() {
-		this.trigger?.classList.remove(this.CLASS_MENU_OPEN);
-		document.body.classList.remove(this.CLASS_MENU_OPEN);
 
-		const setDisplayNone = debounce(() => this.drawerElement.style.display = 'none', 300);
-		setDisplayNone();
-
-		this.enableScroll();
-	}
-	
 	init() {
 		this.trigger.addEventListener('click', () => {
-			if (this.trigger?.classList.contains(this.CLASS_MENU_OPEN)) {
-				this.closeMobileMenu();
+			const expanded = this.drawerElement.getAttribute('aria-expanded');
+
+			this.trigger.disabled = true;
+
+			if (expanded === 'true') {
+				const closeAnimation = this.drawerElement.animate([
+					{ gridTemplateRows: '1fr' },
+					{ gridTemplateRows: '0fr' }
+				], {
+					duration: 300,
+					easing: 'cubic-bezier(0.36, 0, 0.66, -0.56)', // ease-in-back
+					fill: 'both',
+				});
+
+				closeAnimation.onfinish = () => {
+					this.drawerElement.setAttribute('aria-expanded', false);
+					this.trigger.disabled = false;
+
+					if (!this.supportsHasSelector) {
+						this.trigger?.classList.remove(this.CLASS_MENU_OPEN);
+						document.body.classList.remove(this.CLASS_MENU_OPEN);
+
+						// Enable scroll.
+						document.body.classList.remove(this.CLASS_NO_SCROLL);
+					}
+
+				};
 			} else {
-				this.openMobileMenu();
+				this.drawerElement.setAttribute('aria-expanded', true);
+
+				const enterAnimation = this.drawerElement.animate([
+					{ gridTemplateRows: '0fr' },
+					{ gridTemplateRows: '1fr' }
+				], {
+					duration: 500,
+					easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)', // ease-out-back
+					fill: 'both',
+				});
+
+				enterAnimation.onfinish = () => {
+					this.trigger.disabled = false;
+
+					if (!this.supportsHasSelector) {
+						this.trigger?.classList.add(this.CLASS_MENU_OPEN);
+						document.body.classList.add(this.CLASS_MENU_OPEN);
+
+						// Prevent scroll.
+						document.body.classList.add(this.CLASS_NO_SCROLL);
+					}
+				};
 			}
 		});
 	}

--- a/blocks/init/src/Blocks/components/drawer/drawer-style.scss
+++ b/blocks/init/src/Blocks/components/drawer/drawer-style.scss
@@ -1,31 +1,58 @@
 .drawer {
-	$menu: &;
 	position: fixed;
-	top: auto;
-	height: 0;
-	width: 100%;
-	margin: auto;
 
-	display: none;
+	// Top inset is reduced by 1px so the bottom navbar border doesn't overlap the drawer top border.
+	inset: calc(var(--global-navbar-height) - 1px) 0 auto 0;
+
+	z-index: var(--global-z-index-drawer);
+
+	height: calc(100dvh - var(--global-navbar-height));
+
 	overflow-x: hidden;
 
-	background: var(--global-colors-white);
+	&[aria-expanded='false'] {
+		display: none;
+	}
 
-	box-shadow: 0 0 0.15rem rgba(var(--global-colors-black), 0.2);
-	transition: height 0.3s ease-in-out;
+	&[aria-expanded='true'] {
+		display: grid;
+	}
 
-	&.is-open {
-		display: block;
-		padding: var(--global-gutters-default);
-		pointer-events: auto;
+	&__inner {
+		overflow: hidden;
+
+		height: 100%;
+
+		background-color: rgb(var(--global-colors-white-values) / 0.9);
+		backdrop-filter: blur(1.5rem) saturate(1.5);
+
+		padding: var(--global-grid-side-padding);
+		padding-top: 2rem;
+
+		border-top: 1px solid var(--global-colors-gray100);
+
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+
+	// If admin bar is visible.
+	body.admin-bar & {
+		// stylelint-disable-next-line custom-property-pattern
+		inset: calc(var(--global-navbar-height) + var(--wp-admin--admin-bar--height) - 1px) 0 auto 0;
+
+		// stylelint-disable-next-line custom-property-pattern
+		height: calc(100dvh - var(--global-navbar-height) - var(--wp-admin--admin-bar--height));
 	}
 }
 
 body.is-menu-open {
 	overflow: hidden;
+}
 
-	.drawer {
-		pointer-events: auto;
-		height: 100%;
+// NoJS version if :has is supported.
+@supports selector(:has(*)) {
+	body:has(.drawer[aria-expanded='true']) {
+		overflow: hidden;
 	}
 }

--- a/blocks/init/src/Blocks/components/drawer/drawer.php
+++ b/blocks/init/src/Blocks/components/drawer/drawer.php
@@ -25,19 +25,24 @@ $drawerMenu = Components::checkAttr('drawerMenu', $attributes, $manifest);
 $drawerTrigger = Components::checkAttr('drawerTrigger', $attributes, $manifest);
 
 $drawerClass = Components::classnames([
-	Components::selector($componentClass, $componentClass),
+	$componentClass,
+	$componentJsClass,
 	Components::selector($blockClass, $blockClass, $selectorClass),
-	Components::selector($additionalClass, $additionalClass),
-	Components::selector($componentJsClass, $componentJsClass),
+	$additionalClass,
 ]);
 
+$drawerInnerClass = Components::selector($componentClass, $componentClass, 'inner');
 ?>
+
 <div
 	class="<?php echo esc_attr($drawerClass); ?>"
 	data-trigger="<?php echo esc_attr($drawerTrigger); ?>"
+	aria-expanded="false"
 >
-	<?php
-		// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
-		echo $drawerMenu;
-	?>
+	<div class="<?php echo esc_attr($drawerInnerClass); ?>">
+		<?php
+			// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
+			echo $drawerMenu;
+		?>
+	</div>
 </div>

--- a/blocks/init/src/Blocks/components/hamburger/hamburger-style.scss
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger-style.scss
@@ -81,7 +81,8 @@
 		}
 	}
 
-	&.is-menu-open {
+	// Open state.
+	@mixin es-hamburger-open-state {
 		#{$this}__icon {
 			&--top {
 				transform: rotate(45deg) translate3d(0, 20%, 0) scale3d(1, 1, 1);
@@ -106,6 +107,18 @@
 					transform: rotate(-45deg) translate3d(0, -20%, 0) scale3d(1.125, 1, 1);
 				}
 			}
+		}
+	}
+
+	@supports selector(:has(*)) {
+		body:has(.drawer[aria-expanded='true']) & {
+			@include es-hamburger-open-state;
+		}
+	}
+
+	@supports not selector(:has(*)) {
+		&.is-menu-open {
+			@include es-hamburger-open-state;
 		}
 	}
 }

--- a/blocks/init/src/Blocks/components/hamburger/hamburger.php
+++ b/blocks/init/src/Blocks/components/hamburger/hamburger.php
@@ -42,9 +42,9 @@ $iconBtmClass = Components::selector($componentClass, $componentClass, 'icon', '
 
 <button class="<?php echo esc_attr($hamburgerClass); ?>" aria-label="<?php echo esc_attr($hamburgerLabel); ?>">
 	<svg class="<?php echo esc_attr($iconClass); ?>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect class="<?php echo esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="1.5" stroke="black" />
-		<path class="<?php echo esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-		<path class="<?php echo esc_attr($iconMidClass); ?>" d="M7.38464 16H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-		<path class="<?php echo esc_attr($iconBtmClass); ?>" d="M7.38464 22.1538H24.6154" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<rect class="<?php echo esc_attr($iconBorderClass); ?>" opacity="0.1" x="1.23071" y="1.23077" width="29.5385" height="29.5385" rx="5" stroke="black" />
+		<path class="<?php echo esc_attr($iconTopClass); ?>" d="M7.38464 9.84616H24.6154" stroke="black" stroke-linecap="round" stroke-linejoin="round" />
+		<path class="<?php echo esc_attr($iconMidClass); ?>" d="M7.38464 16H24.6154" stroke="black" stroke-linecap="round" stroke-linejoin="round" />
+		<path class="<?php echo esc_attr($iconBtmClass); ?>" d="M7.38464 22.1538H24.6154" stroke="black" stroke-linecap="round" stroke-linejoin="round" />
 	</svg>
 </button>

--- a/blocks/init/src/Blocks/custom/site-footer/components/site-footer-editor.js
+++ b/blocks/init/src/Blocks/custom/site-footer/components/site-footer-editor.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, TextControl } from '@wordpress/components';
+import { LinkEditComponent, PopoverWithTrigger, ReOrderable, ReOrderableItem, checkAttr, classnames, getAttrKey, icons, props, selector } from '@eightshift/frontend-libs/scripts';
+import { ParagraphEditor } from '../../../components/paragraph/components/paragraph-editor';
+import { ImageEditor } from '../../../components/image/components/image-editor';
+import { SocialNetworksEditor } from '../../../components/social-networks/components/social-networks-editor';
+import manifest from '../manifest.json';
+
+export const SiteFooterEditor = ({ attributes, setAttributes }) => {
+	const {
+		blockClass,
+	} = attributes;
+
+	const linksClass = selector(blockClass, blockClass, 'links');
+	const linkClass = classnames(selector(blockClass, blockClass, 'link'), 'es-border-cool-gray-100 es-cursor-pointer es-bg-none es-pl-2 es-pr-1.25 es-py-1 es-rounded-2');
+
+	const siteFooterLinks = checkAttr('siteFooterLinks', attributes, manifest);
+
+	return (
+		<div className={blockClass}>
+			<ImageEditor
+				{...props('logo', attributes, {
+					blockClass: blockClass,
+					selectorClass: 'logo',
+					setAttributes,
+				})}
+			/>
+
+			<ParagraphEditor
+				{...props('copyright', attributes, {
+					blockClass: blockClass,
+					selectorClass: 'copyright',
+					setAttributes,
+				})}
+			/>
+
+			<SocialNetworksEditor
+				{...props('socialNetworks', attributes, {
+					blockClass: blockClass,
+					setAttributes,
+				})}
+			/>
+
+			<div className={linksClass}>
+				<ReOrderable
+					items={siteFooterLinks}
+					attributeName={getAttrKey('siteFooterLinks', attributes, manifest)}
+					setAttributes={setAttributes}
+					noBottomSpacing
+					horizontalVertical
+					additionalHorizontalVerticalContainerClasses='es-h-spaced-wrap'
+				>
+					{siteFooterLinks.map((link, i) => {
+						return (
+							<ReOrderableItem
+								innerClass={linkClass}
+								title={link?.text?.length > 0 ? link.text : <i>{__('New link', 'eightshift-frontend-libs')}</i>}
+								preIcon={
+									<PopoverWithTrigger
+										trigger={({ ref, setIsOpen, isOpen }) => (
+											<button
+												ref={ref}
+												onClick={() => setIsOpen(!isOpen)}
+												className='es-button-reset es-bg-transparent es-cursor-pointer es-color-cool-gray-650 es-hover-color-admin-accent es-mr-1 es-line-h-0'
+											>
+												{icons.editOptions}
+											</button>
+										)}
+										contentClass='es-popover-content es-w-88'
+									>
+										<TextControl
+											label={__('Link text', 'eightshift-frontend-libs')}
+											value={link?.text}
+											onChange={(value) => {
+												const newValue = [...siteFooterLinks];
+												newValue[i].text = value;
+
+												setAttributes({ [getAttrKey('siteFooterLinks', attributes, manifest)]: newValue });
+											}}
+										/>
+
+										<LinkEditComponent
+											label={__('URL', 'eightshift-frontend-libs')}
+											url={link?.url}
+											opensInNewTab={link?.newTab}
+											onChange={({ url, newTab }) => {
+												const newValue = [...siteFooterLinks];
+
+												if (typeof url !== 'undefined') {
+													newValue[i].url = url;
+												}
+
+												if (typeof newTab !== 'undefined') {
+													newValue[i].newTab = newTab;
+												}
+
+												setAttributes({ [getAttrKey('siteFooterLinks', attributes, manifest)]: newValue });
+											}}
+											hideAnchorNotice
+											noBottomSpacing
+										/>
+									</PopoverWithTrigger>
+								}
+								key={link?.id}
+							/>
+						);
+					})}
+
+				</ReOrderable>
+
+				<Button
+					icon={icons.plusCircleFillAlt}
+					className='es-button-square-28 es-button-icon-24'
+					onClick={() => {
+						setAttributes({
+							[getAttrKey('siteFooterLinks', attributes, manifest)]: [...siteFooterLinks, { id: crypto.randomUUID(), url: '', text: '', newTab: false }],
+						});
+					}}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-footer/components/site-footer-options.js
+++ b/blocks/init/src/Blocks/custom/site-footer/components/site-footer-options.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+import { props } from '@eightshift/frontend-libs/scripts';
+import { ImageOptions } from '../../../components/image/components/image-options';
+import { SocialNetworksOptions } from '../../../components/social-networks/components/social-networks-options';
+
+export const SiteFooterOptions = ({ attributes, setAttributes }) => {
+	return (
+		<PanelBody title={__('Site navigation', 'eightshift-frontend-libs')}>
+			<ImageOptions
+				{...props('logo', attributes, { setAttributes })}
+				label={__('Logo', 'eightshift-frontend-libs')}
+				hideRoundedCornersToggle
+				hideFullSizeToggle
+				reducedBottomSpacing
+			/>
+
+			<SocialNetworksOptions
+				{...props('socialNetworks', attributes, { setAttributes })}
+				hideModeSelector
+				noBottomSpacing
+			/>
+		</PanelBody>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-footer/docs/readme.mdx
+++ b/blocks/init/src/Blocks/custom/site-footer/docs/readme.mdx
@@ -1,0 +1,11 @@
+# Site footer Block
+
+A block to use as a footer. You will need to implement a reusable block option and render it inside `footer.php`.
+
+## Implementation
+
+Open a terminal and type in this command inside your projects root:
+
+```shell
+wp boilerplate use_block --name=site-footer
+```

--- a/blocks/init/src/Blocks/custom/site-footer/docs/story.js
+++ b/blocks/init/src/Blocks/custom/site-footer/docs/story.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Gutenberg, blockDetails } from '@eightshift/frontend-libs/scripts/storybook';
+import manifest from './../manifest.json';
+import globalManifest from './../../../manifest.json';
+import readme from './readme.mdx';
+
+export default {
+	title: `Blocks/${manifest.title}`,
+	parameters: {
+		docs: { 
+			page: readme
+		}
+	},
+};
+
+export const block = () => (
+	<Gutenberg props={blockDetails(manifest, globalManifest)} />
+);

--- a/blocks/init/src/Blocks/custom/site-footer/manifest.json
+++ b/blocks/init/src/Blocks/custom/site-footer/manifest.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"blockName": "site-footer",
+	"title": "Site footer",
+	"description": "Footer block with a logo, links, and copyright label.",
+	"category": "eightshift",
+	"icon": {
+		"src": "es-card-teaser-alt-2"
+	},
+	"keywords": [
+		"site",
+		"footer"
+	],
+	"example": {
+		"attributes": {
+			"siteFooterLogoUrl": "https://loremflickr.com/200/150"
+		}
+	},
+	"attributes": {
+		"siteFooterLinks": {
+			"type": "array",
+			"default": []
+		},
+		"wrapperUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"wrapperNoControls": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"components": {
+		"logo": "image",
+		"copyright": "paragraph",
+		"socialNetworks": "social-networks"
+	}
+}

--- a/blocks/init/src/Blocks/custom/site-footer/site-footer-block.js
+++ b/blocks/init/src/Blocks/custom/site-footer/site-footer-block.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { InspectorControls } from '@wordpress/block-editor';
+import { SiteFooterEditor } from './components/site-footer-editor';
+import { SiteFooterOptions } from './components/site-footer-options';
+
+export const SiteFooter = (props) => {
+	return (
+		<>
+			<InspectorControls>
+				<SiteFooterOptions {...props} />
+			</InspectorControls>
+
+			<SiteFooterEditor {...props} />
+		</>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-footer/site-footer-style.scss
+++ b/blocks/init/src/Blocks/custom/site-footer/site-footer-style.scss
@@ -1,0 +1,80 @@
+.block-site-footer {
+	display: flex;
+	flex-direction: column;
+	gap: 2.5rem;
+
+	min-height: 24rem;
+
+	border-top: 1px solid var(--global-colors-gray100);
+
+	padding: var(--global-grid-side-padding);
+
+	@include media(desktop up) {
+		display: grid;
+		grid-template-rows: 1fr auto;
+		grid-template-columns: 1fr 2fr;
+		grid-template-areas: 'logo links' 'copyright socials';
+
+		row-gap: 1rem;
+		column-gap: 5rem;
+	}
+
+	&__logo {
+		grid-area: logo;
+
+		width: 15rem;
+		max-height: 10rem;
+	}
+
+	&__copyright {
+		grid-area: copyright;
+
+		font-size: 0.9rem;
+		color: var(--global-colors-gray500);
+	}
+
+	&__social-networks {
+		grid-area: socials;
+
+		justify-self: flex-end;
+	}
+
+	&__links {
+		grid-area: links;
+
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+
+		row-gap: 1rem;
+		column-gap: 2rem;
+	}
+
+	&__link {
+		@extend %link-reset;
+
+		font-size: 1.25rem;
+		font-weight: 500;
+
+		letter-spacing: -0.01em;
+		text-underline-offset: 0.1em;
+
+		&:hover {
+			color: var(--global-colors-primary500);
+
+			text-decoration: underline var(--global-colors-primary300);
+		}
+	}
+
+	@include media(desktop up) {
+		&__logo,
+		&__links {
+			align-self: flex-start;
+		}
+
+		&__copyright,
+		&__social-networks {
+			align-self: center;
+		}
+	}
+}

--- a/blocks/init/src/Blocks/custom/site-footer/site-footer.php
+++ b/blocks/init/src/Blocks/custom/site-footer/site-footer.php
@@ -13,7 +13,10 @@ $manifest = Components::getManifest(__DIR__);
 $blockClass = $attributes['blockClass'] ?? '';
 
 $siteFooterLinks = Components::checkAttr('siteFooterLinks', $attributes, $manifest);
-$siteFooterLinks = array_filter($siteFooterLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+
+if (!empty($siteFooterLinks)) {
+	$siteFooterLinks = array_filter($siteFooterLinks, fn($item) => !empty($item['text']) && !empty($item['url'])); // @phpstan-ignore-line
+}
 
 $linksClass = Components::selector($blockClass, $blockClass, 'links');
 $linkClass = Components::selector($blockClass, $blockClass, 'link');
@@ -27,17 +30,19 @@ $linkClass = Components::selector($blockClass, $blockClass, 'link');
 	]));
 	?>
 
-	<div class="<?php echo esc_attr($linksClass); ?>">
-		<?php
-		foreach ($siteFooterLinks as $footerLink) { ?>
-			<a
-				class="<?php echo esc_attr($linkClass); ?>"
-				href="<?php echo esc_url($footerLink['url']); ?>"
-			>
-				<?php echo esc_attr($footerLink['text']); ?>
-			</a>
-		<?php } ?>
-	</div>
+	<?php if (!empty($siteFooterLinks)) { ?>
+		<div class="<?php echo esc_attr($linksClass); ?>">
+			<?php
+			foreach ($siteFooterLinks as $footerLink) { ?>
+				<a
+					class="<?php echo esc_attr($linkClass); ?>"
+					href="<?php echo esc_url($footerLink['url']); ?>"
+				>
+					<?php echo esc_attr($footerLink['text']); ?>
+				</a>
+			<?php } ?>
+		</div>
+	<?php } ?>
 
 	<?php
 	echo Components::render('social-networks', Components::props('socialNetworks', $attributes, [

--- a/blocks/init/src/Blocks/custom/site-footer/site-footer.php
+++ b/blocks/init/src/Blocks/custom/site-footer/site-footer.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Template for the Site footer block.
+ *
+ * @package EightshiftBoilerplate
+ */
+
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
+
+$manifest = Components::getManifest(__DIR__);
+
+$blockClass = $attributes['blockClass'] ?? '';
+
+$siteFooterLinks = Components::checkAttr('siteFooterLinks', $attributes, $manifest);
+$siteFooterLinks = array_filter($siteFooterLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+
+$linksClass = Components::selector($blockClass, $blockClass, 'links');
+$linkClass = Components::selector($blockClass, $blockClass, 'link');
+?>
+
+<div class="<?php echo esc_attr($blockClass); ?>">
+	<?php
+	echo Components::render('image', Components::props('logo', $attributes, [
+		'blockClass' => $blockClass,
+		'selectorClass' => 'logo',
+	]));
+	?>
+
+	<div class="<?php echo esc_attr($linksClass); ?>">
+		<?php
+		foreach ($siteFooterLinks as $footerLink) { ?>
+			<a
+				class="<?php echo esc_attr($linkClass); ?>"
+				href="<?php echo esc_url($footerLink['url']); ?>"
+			>
+				<?php echo esc_attr($footerLink['text']); ?>
+			</a>
+		<?php } ?>
+	</div>
+
+	<?php
+	echo Components::render('social-networks', Components::props('socialNetworks', $attributes, [
+		'blockClass' => $blockClass,
+	])),
+	Components::render('paragraph', Components::props('copyright', $attributes, [
+		'blockClass' => $blockClass,
+		'selectorClass' => 'copyright',
+	]));
+	?>
+</div>

--- a/blocks/init/src/Blocks/custom/site-navigation/assets/index.js
+++ b/blocks/init/src/Blocks/custom/site-navigation/assets/index.js
@@ -1,0 +1,34 @@
+import domReady from '@wordpress/dom-ready';
+import manifest from '../manifest.json';
+
+domReady(async () => {
+	const { blockName } = manifest;
+
+	const element = document.querySelector(`.js-block-${blockName}`);
+	const isScrolledClass = 'is-scrolled';
+
+	if (!element) {
+		return;
+	}
+
+	// Optimized scroll listener.
+	let lastKnownScrollPosition = 0;
+	let ticking = false;
+
+	const handleScroll = (scrollPosition) => {
+		element.classList.toggle(isScrolledClass, scrollPosition >= 20);
+	};
+
+	window.addEventListener('scroll', () => {
+		lastKnownScrollPosition = window.scrollY;
+
+		if (!ticking) {
+			window.requestAnimationFrame(() => {
+				handleScroll(lastKnownScrollPosition);
+				ticking = false;
+			});
+
+			ticking = true;
+		}
+	});
+});

--- a/blocks/init/src/Blocks/custom/site-navigation/components/site-navigation-editor.js
+++ b/blocks/init/src/Blocks/custom/site-navigation/components/site-navigation-editor.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, TextControl } from '@wordpress/components';
+import { LinkEditComponent, PopoverWithTrigger, ReOrderable, ReOrderableItem, checkAttr, classnames, getAttrKey, icons, props, selector } from '@eightshift/frontend-libs/scripts';
+import { ImageEditor } from '../../../components/image/components/image-editor';
+import manifest from '../manifest.json';
+
+export const SiteNavigationEditor = ({ attributes, setAttributes }) => {
+	const {
+		blockClass,
+	} = attributes;
+
+	const linksClass = selector(blockClass, blockClass, 'links');
+	const linkClass = classnames(selector(blockClass, blockClass, 'link'), 'es-border-cool-gray-100 es-cursor-pointer es-bg-none es-pl-2 es-pr-1.25 es-py-1 es-rounded-2');
+
+	const siteNavigationLinks = checkAttr('siteNavigationLinks', attributes, manifest);
+
+	return (
+		<div className={blockClass}>
+			<ImageEditor
+				{...props('logo', attributes, {
+					setAttributes,
+					blockClass: blockClass,
+					selectorClass: 'logo',
+				})}
+			/>
+
+			<div className={linksClass}>
+				<ReOrderable
+					items={siteNavigationLinks}
+					attributeName={getAttrKey('siteNavigationLinks', attributes, manifest)}
+					setAttributes={setAttributes}
+					noBottomSpacing
+					horizontalVertical
+					additionalHorizontalVerticalContainerClasses='es-h-spaced-wrap'
+				>
+					{siteNavigationLinks.map((link, i) => {
+						return (
+							<ReOrderableItem
+								innerClass={linkClass}
+								title={link?.text?.length > 0 ? link.text : <i>{__('New link', 'eightshift-frontend-libs')}</i>}
+								preIcon={
+									<PopoverWithTrigger
+										trigger={({ ref, setIsOpen, isOpen }) => (
+											<button
+												ref={ref}
+												onClick={() => setIsOpen(!isOpen)}
+												className='es-button-reset es-bg-transparent es-cursor-pointer es-color-cool-gray-650 es-hover-color-admin-accent es-mr-1 es-line-h-0'
+											>
+												{icons.editOptions}
+											</button>
+										)}
+										contentClass='es-popover-content es-w-88'
+									>
+										<TextControl
+											label={__('Link text', 'eightshift-frontend-libs')}
+											value={link?.text}
+											onChange={(value) => {
+												const newValue = [...siteNavigationLinks];
+												newValue[i].text = value;
+
+												setAttributes({ [getAttrKey('siteNavigationLinks', attributes, manifest)]: newValue });
+											}}
+										/>
+
+										<LinkEditComponent
+											label={__('URL', 'eightshift-frontend-libs')}
+											url={link?.url}
+											opensInNewTab={link?.newTab}
+											onChange={({ url, newTab }) => {
+												const newValue = [...siteNavigationLinks];
+
+												if (typeof url !== 'undefined') {
+													newValue[i].url = url;
+												}
+
+												if (typeof newTab !== 'undefined') {
+													newValue[i].newTab = newTab;
+												}
+
+												setAttributes({ [getAttrKey('siteNavigationLinks', attributes, manifest)]: newValue });
+											}}
+											hideAnchorNotice
+											noBottomSpacing
+										/>
+									</PopoverWithTrigger>
+								}
+								key={link?.id}
+							/>
+						);
+					})}
+
+				</ReOrderable>
+
+				<Button
+					icon={icons.plusCircleFillAlt}
+					className='es-button-square-28 es-button-icon-24'
+					onClick={() => {
+						setAttributes({
+							[getAttrKey('siteNavigationLinks', attributes, manifest)]: [...siteNavigationLinks, { id: crypto.randomUUID(), url: '', text: '', newTab: false }],
+						});
+					}}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-navigation/components/site-navigation-options.js
+++ b/blocks/init/src/Blocks/custom/site-navigation/components/site-navigation-options.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+import { props } from '@eightshift/frontend-libs/scripts';
+import { ImageOptions } from '../../../components/image/components/image-options';
+
+export const SiteNavigationOptions = ({ attributes, setAttributes }) => {
+	return (
+		<PanelBody title={__('Site navigation', 'eightshift-frontend-libs')}>
+			<ImageOptions
+				{...props('logo', attributes, { setAttributes })}
+				label={__('Logo', 'eightshift-frontend-libs')}
+				hideFullSizeToggle
+				hideRoundedCornersToggle
+				noBottomSpacing
+			/>
+		</PanelBody>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-navigation/docs/readme.mdx
+++ b/blocks/init/src/Blocks/custom/site-navigation/docs/readme.mdx
@@ -1,0 +1,11 @@
+# Site navigation Block
+
+A block to use instead of the default navigation. You will need to implement a reusable block option and render it inside `header.php`.
+
+## Implementation
+
+Open a terminal and type in this command inside your projects root:
+
+```shell
+wp boilerplate use_block --name=site-navigation
+```

--- a/blocks/init/src/Blocks/custom/site-navigation/docs/story.js
+++ b/blocks/init/src/Blocks/custom/site-navigation/docs/story.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Gutenberg, blockDetails } from '@eightshift/frontend-libs/scripts/storybook';
+import manifest from './../manifest.json';
+import globalManifest from './../../../manifest.json';
+import readme from './readme.mdx';
+
+export default {
+	title: `Blocks/${manifest.title}`,
+	parameters: {
+		docs: { 
+			page: readme
+		}
+	},
+};
+
+export const block = () => (
+	<Gutenberg props={blockDetails(manifest, globalManifest)} />
+);

--- a/blocks/init/src/Blocks/custom/site-navigation/manifest.json
+++ b/blocks/init/src/Blocks/custom/site-navigation/manifest.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"blockName": "site-navigation",
+	"title": "Site navigation",
+	"description": "Main site navigation with a logo, links, and mobile menu button.",
+	"category": "eightshift",
+	"icon": {
+		"src": "es-navbar"
+	},
+	"keywords": [
+		"site",
+		"navigation",
+		"navbar"
+	],
+	"example": {
+		"attributes": {
+			"siteNavigationLogoUrl": "https://loremflickr.com/200/150"
+		}
+	},
+	"attributes": {
+		"siteNavigationLinks": {
+			"type": "array",
+			"default": []
+		},
+		"wrapperUse": {
+			"type": "boolean",
+			"default": false
+		},
+		"wrapperNoControls": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"components": {
+		"logo": "image"
+	}
+}

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation-block.js
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation-block.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { InspectorControls } from '@wordpress/block-editor';
+import { SiteNavigationEditor } from './components/site-navigation-editor';
+import { SiteNavigationOptions } from './components/site-navigation-options';
+
+export const SiteNavigation = (props) => {
+	return (
+		<>
+			<InspectorControls>
+				<SiteNavigationOptions {...props} />
+			</InspectorControls>
+
+			<SiteNavigationEditor {...props} />
+		</>
+	);
+};

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation-editor.scss
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation-editor.scss
@@ -1,0 +1,3 @@
+.block-site-navigation {
+	position: static;
+}

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation-style.scss
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation-style.scss
@@ -1,0 +1,74 @@
+.block-site-navigation {
+	position: fixed;
+	inset: 0 0 auto 0;
+
+	padding-inline: var(--global-grid-side-padding);
+
+	height: var(--global-navbar-height);
+
+	display: flex;
+	align-items: center;
+	gap: 2.5rem;
+
+	background-color: rgb(var(--global-colors-white-values) / 0.8);
+	border-bottom: 1px solid rgb(var(--global-colors-gray100-values) / 0);
+
+	backdrop-filter: blur(1.5rem) saturate(1.5) brightness(1.25);
+
+	z-index: var(--global-z-index-header);
+
+	transition: {
+		property: border-color, background-color;
+		timing-function: ease-out;
+		duration: 0.3s;
+	}
+
+	&.is-scrolled {
+		border-bottom-color: var(--global-colors-gray100);
+	}
+
+	&__logo {
+		width: 15rem;
+		max-height: 10rem;
+	}
+
+	&__links {
+		display: none;
+
+		align-items: center;
+		gap: 1.5rem;
+
+		margin-inline-start: auto;
+
+		@include media(desktop up) {
+			display: flex;
+		}
+	}
+
+	&__link {
+		@extend %link-reset;
+
+		letter-spacing: -0.01em;
+		text-underline-offset: 0.1em;
+
+		&:hover {
+			color: var(--global-colors-primary500);
+
+			text-decoration: underline var(--global-colors-primary300);
+		}
+
+		@include media(tablet down) {
+			font-size: 1.75rem;
+		}
+	}
+
+	&__hamburger {
+		margin-inline-start: auto;
+	}
+
+	// Move it out of the way of the admin bar.
+	body.admin-bar & {
+		// stylelint-disable-next-line custom-property-pattern
+		top: var(--wp-admin--admin-bar--height);
+	}
+}

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
@@ -14,7 +14,10 @@ $blockClass = $attributes['blockClass'] ?? '';
 $blockJsClass = $attributes['blockJsClass'] ?? '';
 
 $siteNavigationLinks = Components::checkAttr('siteNavigationLinks', $attributes, $manifest);
-$siteNavigationLinks = array_filter($siteNavigationLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+
+if (!empty($siteNavigationLinks)) {
+	$siteNavigationLinks = array_filter($siteNavigationLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+}
 
 $navbarClass = Components::classnames([
 	$blockClass,
@@ -42,12 +45,14 @@ foreach ($siteNavigationLinks as $navbarLink) {
 	]));
 	?>
 
-	<div class="<?php echo esc_attr($linksClass); ?>">
-		<?php
-		// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
-		echo $linksToShow;
-		?>
-	</div>
+	<?php if (!empty($linksToShow)) { ?>
+		<div class="<?php echo esc_attr($linksClass); ?>">
+			<?php
+			// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
+			echo $linksToShow;
+			?>
+		</div>
+	<?php } ?>
 
 	<?php
 	echo Components::render('hamburger', [

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
@@ -13,10 +13,10 @@ $manifest = Components::getManifest(__DIR__);
 $blockClass = $attributes['blockClass'] ?? '';
 $blockJsClass = $attributes['blockJsClass'] ?? '';
 
-$siteNavigationLinks = Components::checkAttr('siteNavigationLinks', $attributes, $manifest);
+$siteNavigationLinks = Components::checkAttr('siteNavigationLinks', $attributes, $manifest) ?? [];
 
 if (!empty($siteNavigationLinks)) {
-	$siteNavigationLinks = array_filter($siteNavigationLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+	$siteNavigationLinks = array_filter($siteNavigationLinks, fn($item) => !empty($item['text']) && !empty($item['url'])); // @phpstan-ignore-line
 }
 
 $navbarClass = Components::classnames([
@@ -29,11 +29,13 @@ $linkClass = Components::selector($blockClass, $blockClass, 'link');
 
 $linksToShow = '';
 
-foreach ($siteNavigationLinks as $navbarLink) {
-	$url = esc_url($navbarLink['url']);
-	$text = esc_attr($navbarLink['text']);
+if (!empty($siteNavigationLinks)) {
+	foreach ($siteNavigationLinks as $navbarLink) {
+		$url = esc_url($navbarLink['url']);
+		$text = esc_attr($navbarLink['text']);
 
-	$linksToShow .= "<a class='{$linkClass}' href='{$url}'>{$text}</a>";
+		$linksToShow .= "<a class='{$linkClass}' href='{$url}'>{$text}</a>";
+	}
 }
 ?>
 

--- a/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
+++ b/blocks/init/src/Blocks/custom/site-navigation/site-navigation.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Template for the Site navigation block.
+ *
+ * @package EightshiftBoilerplate
+ */
+
+use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
+
+$manifest = Components::getManifest(__DIR__);
+
+$blockClass = $attributes['blockClass'] ?? '';
+$blockJsClass = $attributes['blockJsClass'] ?? '';
+
+$siteNavigationLinks = Components::checkAttr('siteNavigationLinks', $attributes, $manifest);
+$siteNavigationLinks = array_filter($siteNavigationLinks, fn($item) => !empty($item['text']) && !empty($item['url']));
+
+$navbarClass = Components::classnames([
+	$blockClass,
+	$blockJsClass,
+]);
+
+$linksClass = Components::selector($blockClass, $blockClass, 'links');
+$linkClass = Components::selector($blockClass, $blockClass, 'link');
+
+$linksToShow = '';
+
+foreach ($siteNavigationLinks as $navbarLink) {
+	$url = esc_url($navbarLink['url']);
+	$text = esc_attr($navbarLink['text']);
+
+	$linksToShow .= "<a class='{$linkClass}' href='{$url}'>{$text}</a>";
+}
+?>
+
+<nav class="<?php echo esc_attr($navbarClass); ?>">
+	<?php
+	echo Components::render('image', Components::props('logo', $attributes, [
+		'blockClass' => $blockClass,
+		'selectorClass' => 'logo',
+	]));
+	?>
+
+	<div class="<?php echo esc_attr($linksClass); ?>">
+		<?php
+		// phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
+		echo $linksToShow;
+		?>
+	</div>
+
+	<?php
+	echo Components::render('hamburger', [
+		'blockClass' => $blockClass,
+	]);
+	?>
+</nav>
+
+<?php
+echo Components::render('drawer', [
+	'drawerTrigger' => 'js-hamburger',
+	'drawerMenu' => $linksToShow,
+]);

--- a/blocks/init/src/Blocks/manifest.json
+++ b/blocks/init/src/Blocks/manifest.json
@@ -22,9 +22,9 @@
 		"maxCols": 12,
 		"baseFont": "'DM Sans'",
 		"zIndex": {
-			"header": 100,
-			"drawer": 99,
-			"overlay": 98
+			"overlay": 98,
+			"header": 99,
+			"drawer": 100
 		},
 		"breakpoints": {
 			"mobile": 480,

--- a/scripts/components/fancy-divider/fancy-divider.js
+++ b/scripts/components/fancy-divider/fancy-divider.js
@@ -28,7 +28,7 @@ export const FancyDivider = (props) => {
 		<div className={classnames('es-h-spaced es-nested-p-0.75 es-nested-bg-cool-gray-450 es-nested-rounded-1 es-nested-color-pure-white es-color-cool-gray-600', hasTopSpacing && 'es-mt-3', !noBottomSpacing && 'es-mb-2.5', additionalClasses)}>
 			<IconLabel icon={icon} label={label} subtitle={subtitle} standalone additionalClasses='es-nested-bg-cool-gray-450 es-nested-rounded-1 es-nested-color-pure-white! es-has-enhanced-contrast-icon' />
 
-			<div className='es-w-full es-flex-1 es-h-px es-bg-cool-gray-50'></div>
+			<div className='es-w-full es-flex-1 es-h-px es-bg-cool-gray-100'></div>
 		</div>
 	);
 };


### PR DESCRIPTION
Adds a "Site navigation" and "Site footer" block, to enable making use of WP menus a history 😄 

Also reworked is the drawer component, so it better integrates with the new blocks, and also uses way less JS (especially if the browser supports the `:has()` selector)

**Note**: this won't currently replace the existing header and footer, need to think about a nice (and ACF-less) way to do that 😄 

(solves #644)

**Site navigation block**
![image](https://github.com/infinum/eightshift-frontend-libs/assets/77000136/34d7d4af-4886-4b79-91f0-9313131af38c)

**Site footer block**
![image](https://github.com/infinum/eightshift-frontend-libs/assets/77000136/ca74b823-ea90-48b0-9a37-112c7903c11e)

Most of the editing is done through the editor, and all the links are drag&droppable for reordering
![image](https://github.com/infinum/eightshift-frontend-libs/assets/77000136/f0103b33-1b09-49d6-8e36-c32f853620cd)
