### PR TITLE
Add option to select wrapper HTML tag

### DIFF
--- a/blocks/init/src/Blocks/wrapper/components/wrapper-editor.js
+++ b/blocks/init/src/Blocks/wrapper/components/wrapper-editor.js
@@ -20,7 +20,7 @@ export const WrapperEditor = ({ attributes, setAttributes, children }) => {
 	const wrapperOffsetLarge = checkAttr('wrapperOffsetLarge', attributes, manifest, true);
 	const wrapperWidthLarge = checkAttr('wrapperWidthLarge', attributes, manifest, true);
 
-	// First letter for WrapperTag is capitalized on purpose. That way it can be used as a dynamic tag.
+	// First letter of WrapperTag variable is capitalized on purpose. That way it can be used as a dynamic tag.
 	const WrapperTag = checkAttr('wrapperTag', attributes, manifest);
 
 	const {

--- a/blocks/init/src/Blocks/wrapper/components/wrapper-editor.js
+++ b/blocks/init/src/Blocks/wrapper/components/wrapper-editor.js
@@ -20,6 +20,9 @@ export const WrapperEditor = ({ attributes, setAttributes, children }) => {
 	const wrapperOffsetLarge = checkAttr('wrapperOffsetLarge', attributes, manifest, true);
 	const wrapperWidthLarge = checkAttr('wrapperWidthLarge', attributes, manifest, true);
 
+	// First letter for WrapperTag is capitalized on purpose. That way it can be used as a dynamic tag.
+	const WrapperTag = checkAttr('wrapperTag', attributes, manifest);
+
 	const {
 		blockClientId,
 	} = attributes;
@@ -82,7 +85,7 @@ export const WrapperEditor = ({ attributes, setAttributes, children }) => {
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
-		<div ref={reference} style={gridWidth} className={wrapperClass} data-id={unique} id={wrapperId}>
+		<WrapperTag ref={reference} style={gridWidth} className={wrapperClass} data-id={unique} id={wrapperId}>
 			<GridGuides
 				previewVisible={previewVisible}
 				wrapperIsFullWidthLarge={wrapperIsFullWidthLarge}
@@ -107,6 +110,6 @@ export const WrapperEditor = ({ attributes, setAttributes, children }) => {
 				wrapperOffsetLarge={wrapperOffsetLarge}
 				wrapperIsFullWidthLarge={wrapperIsFullWidthLarge}
 			/>
-		</div>
+		</WrapperTag>
 	);
 };

--- a/blocks/init/src/Blocks/wrapper/components/wrapper-options.js
+++ b/blocks/init/src/Blocks/wrapper/components/wrapper-options.js
@@ -37,6 +37,7 @@ export const WrapperOptions = ({ attributes, setAttributes }) => {
 		showWrapperBgColorPicker = true,
 		showWrapperWidth = true,
 		showWrapperOffset = true,
+		showWrapperTag = true,
 		showWrapperSpacingTop = true,
 		showWrapperSpacingBottom = true,
 		showWrapperSpacingTopIn = true,
@@ -73,6 +74,8 @@ export const WrapperOptions = ({ attributes, setAttributes }) => {
 	const dividerColors = getOption('wrapperDividerColor', attributes, manifest, true);
 	const backgroundColors = getOption('wrapperBgColorProject', attributes, manifest, true);
 
+	const wrapperTagOptions = getOption('wrapperTag', attributes, manifest);
+
 	const isEditMode = useSelect((select) => select('core/block-editor').isNavigationMode());
 
 	const wrapperUse = checkAttr('wrapperUse', attributes, manifest);
@@ -82,6 +85,7 @@ export const WrapperOptions = ({ attributes, setAttributes }) => {
 	const wrapperSimple = checkAttr('wrapperSimple', attributes, manifest);
 	const wrapperId = checkAttr('wrapperId', attributes, manifest);
 	const wrapperAnchorId = checkAttr('wrapperAnchorId', attributes, manifest);
+	const wrapperTag = checkAttr('wrapperTag', attributes, manifest);
 
 	const wrapperBgColorType = checkAttr('wrapperBgColorType', attributes, manifest);
 	const wrapperBgColorProject = checkAttr('wrapperBgColorProject', attributes, manifest);
@@ -271,6 +275,21 @@ export const WrapperOptions = ({ attributes, setAttributes }) => {
 							onAfterChange={() => dispatch(WRAPPER_STORE_NAME).hidePreview()}
 						/>
 					}
+
+					<Section
+						icon={icons.code}
+						label={__('Wrapper tag', 'eightshift-frontend-libs')}
+						showIf={showWrapperTag}
+					>
+						<OptionSelector
+							options={wrapperTagOptions}
+							value={wrapperTag}
+							onChange={(value) => setAttributes({ wrapperTag: value })}
+							additionalButtonClass='es-v-spaced es-w-16 es-text-3 es-content-center'
+							noBottomSpacing={getWrapperUseOptionName() === 'off'}
+							alignment='center'
+						/>
+					</Section>
 
 					<Section
 						icon={icons.ruler}

--- a/blocks/init/src/Blocks/wrapper/components/wrapper-options.js
+++ b/blocks/init/src/Blocks/wrapper/components/wrapper-options.js
@@ -276,20 +276,17 @@ export const WrapperOptions = ({ attributes, setAttributes }) => {
 						/>
 					}
 
-					<Section
-						icon={icons.code}
-						label={__('Wrapper tag', 'eightshift-frontend-libs')}
-						showIf={showWrapperTag}
-					>
+					{wrapperUse && showWrapperTag &&
 						<OptionSelector
+							label={__('Wrapper tag', 'eightshift-frontend-libs')}
+							icon={icons.code}
 							options={wrapperTagOptions}
 							value={wrapperTag}
 							onChange={(value) => setAttributes({ wrapperTag: value })}
 							additionalButtonClass='es-v-spaced es-w-16 es-text-3 es-content-center'
-							noBottomSpacing={getWrapperUseOptionName() === 'off'}
 							alignment='center'
 						/>
-					</Section>
+					}
 
 					<Section
 						icon={icons.ruler}

--- a/blocks/init/src/Blocks/wrapper/manifest.json
+++ b/blocks/init/src/Blocks/wrapper/manifest.json
@@ -71,6 +71,11 @@
 			"default": false
 		},
 
+		"wrapperTag": {
+			"type": "string",
+			"default": "div"
+		},
+
 		"wrapperBgColorType": {
 			"type": "string",
 			"default": "project"
@@ -402,6 +407,24 @@
 			"fullMax": 14,
 			"step": 1
 		},
+		"wrapperTag": [
+			{
+				"value": "div",
+				"label": "<div>"
+			},
+			{
+				"value": "section",
+				"label": "<section>"
+			},
+			{
+				"value": "aside",
+				"label": "<aside>"
+			},
+			{
+				"value": "article",
+				"label": "<article>"
+			}
+		],
 		"breakpoints": [
 			"large",
 			"desktop",

--- a/blocks/init/src/Blocks/wrapper/wrapper.php
+++ b/blocks/init/src/Blocks/wrapper/wrapper.php
@@ -38,6 +38,7 @@ if (! $wrapperUse || $wrapperNoControls) {
 	return;
 }
 
+$wrapperTag = Components::checkAttr('wrapperTag', $attributes, $manifest);
 $wrapperId = Components::checkAttr('wrapperId', $attributes, $manifest);
 $wrapperAnchorId = Components::checkAttr('wrapperAnchorId', $attributes, $manifest);
 $wrapperMainClass = $attributes['componentClass'] ?? $manifest['componentClass'];
@@ -53,7 +54,7 @@ $attributes["uniqueWrapperId"] = $unique;
 
 ?>
 
-<div
+<<?php echo esc_attr($wrapperTag); ?>
 	class="<?php echo esc_attr($wrapperClass); ?>"
 	data-id="<?php echo esc_attr($unique); ?>"
 	<?php echo $wrapperId ? 'id="' . esc_attr($wrapperId) . '"' : ''; ?>
@@ -88,4 +89,4 @@ $attributes["uniqueWrapperId"] = $unique;
 		);
 	}
 	?>
-</div>
+</<?php echo esc_attr($wrapperTag); ?>>


### PR DESCRIPTION
# Description
Closes #732.

- adds an option to select wrapper HTML tag. Defaults to `<div>`. Other options include `<section>`, `<aside>`, `<article>`
- available on `Spacing Only` and `Spacing & Layout`

### Notes
Currently doesn't work on `Column` block. Do we need this option there as well?

If you have any questions or suggestions, let me know.


# Screenshots / Videos
**Options**
<img width="301" alt="Screenshot 2023-06-26 at 15 24 51" src="https://github.com/infinum/eightshift-frontend-libs/assets/23059501/b4c0a607-f5dc-48f0-bba6-abb181b5021c">

**Wrapper with `<article>` tag**
<img width="1511" alt="Screenshot 2023-06-26 at 16 06 44" src="https://github.com/infinum/eightshift-frontend-libs/assets/23059501/0babb87a-80e3-49e4-876f-29d6535beb28">



