### PR TITLE
Override eslint rules - @infinumjs max line length

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-	"extends": "./linters/eslint.config.js"
+	"extends": "./linters/eslint.config.js",
+	"rules": {
+		"max-len": 0
+	}
 }


### PR DESCRIPTION
# Description

Updated eslint rules to override @infinumjs recent changes.

The `max-len` of 120 seems like an overkill and this PR removes the restriction entirely.
Other two changes that were introduced `padding-line-between-statements` & `react/self-closing-comp` and could generate errors on existing projects, if were to updated to latest ESFEL, seem sensible so I left those.

Feel free to weigh in in the comments
