### PR TITLE
Update attributes.js

### DIFF
--- a/scripts/editor/attributes.js
+++ b/scripts/editor/attributes.js
@@ -21,7 +21,8 @@ import _ from 'lodash';
  *     select,
  *     props.clientId,
  *     {
- *       wrapperDisable: true,
+ *       wrapperUse: false,
+ *       wrapperNoControls: true,
  *     }
  *   );
  * });


### PR DESCRIPTION
Update to DocBlock of `overrideInnerBlockAttributes`.  `wrapperDisable` is not a valid attribute. Replaced by `wrapperUse` and `wrapperNoControls`