### PR TITLE
WP 6.4 fixes

### DIFF
--- a/blocks/init/src/Blocks/custom/columns/manifest.json
+++ b/blocks/init/src/Blocks/custom/columns/manifest.json
@@ -216,8 +216,8 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 12,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "12",
+						"columnOffsetLarge": "2"
 					}
 				}
 			]
@@ -229,14 +229,14 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 6,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "6",
+						"columnOffsetLarge": "2"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 6
+						"columnWidthLarge": "6"
 					}
 				}
 			]
@@ -248,20 +248,20 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 4,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "4",
+						"columnOffsetLarge": "2"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 4
+						"columnWidthLarge": "4"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 4
+						"columnWidthLarge": "4"
 					}
 				}
 			]
@@ -273,26 +273,26 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "3",
+						"columnOffsetLarge": "2"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3
+						"columnWidthLarge": "3"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3
+						"columnWidthLarge": "3"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3
+						"columnWidthLarge": "3"
 					}
 				}
 			]
@@ -304,14 +304,14 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "3",
+						"columnOffsetLarge": "2"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 9
+						"columnWidthLarge": "9"
 					}
 				}
 			]
@@ -323,14 +323,14 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 9,
-						"columnOffsetLarge": 2
+						"columnWidthLarge": "9",
+						"columnOffsetLarge": "2"
 					}
 				},
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 3
+						"columnWidthLarge": "3"
 					}
 				}
 			]
@@ -342,8 +342,8 @@
 				{
 					"name": "eightshift-boilerplate/column",
 					"attributes": {
-						"columnWidthLarge": 14,
-						"columnOffsetLarge": 1
+						"columnWidthLarge": "14",
+						"columnOffsetLarge": "1"
 					}
 				}
 			]

--- a/scripts/components/custom-slider/shared.js
+++ b/scripts/components/custom-slider/shared.js
@@ -125,7 +125,8 @@ export const columnConfigStyleProps = (props, sliderHeight, numColumns) => {
 	};
 
 	const trackStyle = {
-		background: disabled ? 'var(--es-admin-cool-gray-100)' : 'linear-gradient(135deg, var(--es-admin-cool-gray-200), var(--es-admin-cool-gray-400))',
+		backgroundColor: 'none !important',
+		background: 'linear-gradient(135deg, var(--es-admin-cool-gray-200), var(--es-admin-cool-gray-400))',
 		borderTopLeftRadius: props.value[0] === 1 ? 5 : 2,
 		borderBottomLeftRadius: props.value[0] === 1 ? 5 : 2,
 		borderTopRightRadius: props.value[1] === numColumns ? 5 : 2,
@@ -133,9 +134,12 @@ export const columnConfigStyleProps = (props, sliderHeight, numColumns) => {
 		height: 34,
 		top: 11,
 		cursor: 'pointer',
-		zIndex: -1,
+		zIndex: 0,
 		backgroundOrigin: 'border-box',
 		backgroundRepeat: 'no-repeat',
+		backgroundClip: 'border-box',
+		opacity: disabled ? 0.5 : 1,
+		borderRadius: 4,
 	};
 
 	const railStyle = {
@@ -164,6 +168,7 @@ export const columnConfigStyleProps = (props, sliderHeight, numColumns) => {
 			bottom: -39,
 			opacity: disabled ? 0 : 1,
 			borderRadius: 2,
+			zIndex: 1,
 		};
 
 		const activeStyle = {

--- a/styles/override-editor.scss
+++ b/styles/override-editor.scss
@@ -174,6 +174,7 @@ body {
 @import './wp-version-specific/wp-6-1';
 @import './wp-version-specific/wp-6-2';
 @import './wp-version-specific/wp-6-3';
+@import './wp-version-specific/wp-6-4';
 
 @import './es-utility-classes.scss';
 @import './es-component-styles.scss';

--- a/styles/wp-version-specific/_wp-6-4.scss
+++ b/styles/wp-version-specific/_wp-6-4.scss
@@ -1,0 +1,116 @@
+// stylelint-disable
+
+// WP 6.4 fixes
+body.branch-6-4 {
+	// Fix label casing.
+	.components-base-control__label {
+		text-transform: inherit !important;
+		font-size: inherit !important;
+		font-weight: inherit !important;
+	}
+
+	// Fix label styling and stylize SVGs
+	.components-base-control__label,
+	.components-input-control__label {
+		display: flex;
+		align-items: center;
+		gap: var(--es-gutenberg-base-control-label-gap, 0.5rem);
+
+		margin: var(--es-gutenberg-base-control-label-margin, 0 0 0.5rem);
+		width: 100%;
+
+		svg {
+			height: 1.5rem;
+			width: 1.5rem;
+			margin: 0;
+
+			flex-shrink: 0;
+
+			&:not(button svg) {
+				color: var(--es-admin-components-base-control-svg, var(--es-admin-cool-gray-500));
+			}
+		}
+
+		button {
+			margin-left: auto !important;
+		}
+	}
+
+	// Fix ToggleControl flex.
+	.components-toggle-control {
+		.components-h-stack {
+			flex-direction: row-reverse !important;
+			align-items: center !important;
+			justify-content: space-between !important;
+		}
+	}
+
+	// Fix block icons being misaligned.
+	.block-editor-block-icon.has-colors svg,
+	.components-button.components-toolbar-button.block-editor-block-parent-selector__button.has-icon .block-editor-block-icon svg,
+	.block-editor-block-toolbar__block-controls .block-editor-block-switcher .components-dropdown-menu__toggle .block-editor-block-icon svg {
+		width: 1.25rem !important;
+		height: 1.25rem !important;
+	}
+
+	// Improve block inserter display and positioning.
+	.components-dropdown.block-editor-inserter {
+		display: flex !important;
+		align-items: center;
+		justify-self: center;
+	}
+
+	.block-editor-block-list__block .block-list-appender {
+		position: static !important;
+		margin: 0.75rem 0.25rem 0 !important;
+
+		display: flex !important;
+		justify-content: center !important;
+		align-items: center !important;
+
+		max-width: 100% !important;
+
+		pointer-events: none !important;
+
+		> * {
+			pointer-events: all;
+		}
+	}
+
+	// Fix NumberPicker margin.
+	.components-base-control.components-input-control.components-number-control {
+		margin-bottom: 0 !important;
+	}
+
+	// Fix inserter block icons on hover.
+	.components-button.block-editor-block-types-list__item:not(:disabled):hover svg {
+		color:currentColor !important;
+	}
+
+	// Improve sidebar block icon.
+	.block-editor-inserter__preview-container .block-editor-block-card,
+	.block-editor-block-inspector .block-editor-block-card {
+		span {
+			line-height: 0;
+		}
+
+		svg {
+			width: 1.875rem !important;
+			height: 1.875rem !important;
+			max-width: 1.875rem;
+			max-height: 1.875rem;
+		}
+	}
+
+	// Fix buttons with icon & text having extra padding.
+	.components-button.has-icon.has-text {
+		padding-right: 6px; // Default WP value.
+	}
+
+	// Add some line height to the post title.
+	.wp-block-post-title.editor-post-title.editor-post-title__input {
+		line-height: 1.1 !important;
+	}
+}
+
+// stylelint-enable


### PR DESCRIPTION
Changes:
- added WP 6.4 style overrides
- fixed Columns default presets
- fixed RangeSlider ColumnPicker variant click and drag

Closes #763 