### PR TITLE
Fix current term querying

### DIFF
--- a/blocks/init/src/Blocks/custom/featured-content/featured-content.php
+++ b/blocks/init/src/Blocks/custom/featured-content/featured-content.php
@@ -59,7 +59,7 @@ if ($featuredContentTaxonomy) {
 		$currentTerms = get_the_terms($post->ID, strval($featuredContentTaxonomy));
 
 		if ($currentTerms) {
-			$args['tax_query'][0]['terms'] = [$currentTerms[0]->term_id];
+			$args['tax_query'][0]['terms'] = wp_list_pluck($currentTerms, 'term_id');
 		}
 	} else {
 		$args['tax_query'][0]['operator'] = 'NOT IN'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query


### PR DESCRIPTION
Fixes a bug where if the current post has multiple terms (is in multiple categories), only the first one would be used in the block query.