### PR TITLE
Frontend libs 9.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.3.1] - 2024-02-06
+
+### Updated
+- Move `@babel/preset-react` to dependencies (from devDependencies)
+
 ## [9.3.0] - 2024-02-06
 
 ### Added
@@ -939,6 +944,7 @@ Follow this migration script in order for you project to work correctly with the
 
 [Unreleased]: https://github.com/infinum/eightshift-frontend-libs/compare/master...HEAD
 
+[9.3.1]: https://github.com/infinum/eightshift-frontend-libs/compare/9.3.0...9.3.1
 [9.3.0]: https://github.com/infinum/eightshift-frontend-libs/compare/9.2.1...9.3.0
 [9.2.1]: https://github.com/infinum/eightshift-frontend-libs/compare/9.2.0...9.2.1
 [9.2.0]: https://github.com/infinum/eightshift-frontend-libs/compare/9.1.0...9.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/frontend-libs",
-	"version": "9.3.0",
+	"version": "9.3.1",
 	"description": "A collection of useful frontend utility modules. powered by Eightshift",
 	"author": {
 		"name": "Eightshift team",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@babel/cli": "^7.23.9",
 		"@babel/eslint-parser": "^7.23.10",
 		"@babel/eslint-plugin": "^7.23.5",
+		"@babel/preset-react": "^7.23.3",
 		"@dnd-kit/core": "^6.1.0",
 		"@dnd-kit/modifiers": "^7.0.0",
 		"@dnd-kit/sortable": "^8.0.0",
@@ -106,7 +107,6 @@
 	},
 	"devDependencies": {
 		"@babel/preset-env": "^7.23.7",
-		"@babel/preset-react": "^7.23.3",
 		"@eightshift/storybook": "^1.6.0",
 		"@jest/globals": "^29.7.0",
 		"babel-jest": "^29.7.0",


### PR DESCRIPTION
Moves `@babel/preset-react` to dependencies (from devDependencies)