### PR TITLE
Frontend libs 9.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.5.0] - 2024-02-21
+
+### Updated
+- Fixed block renaming (due to recent Gutenberg changes)
+- `LinkInput` should now pop the suggestion panel only when focused into the input field
+- Fixed typo in `MultiSelect` story
+
 ## [9.4.2] - 2024-02-21
 
 ### Updated
@@ -969,6 +976,7 @@ Follow this migration script in order for you project to work correctly with the
 
 [Unreleased]: https://github.com/infinum/eightshift-frontend-libs/compare/master...HEAD
 
+[9.5.0]: https://github.com/infinum/eightshift-frontend-libs/compare/9.4.2...9.5.0
 [9.4.2]: https://github.com/infinum/eightshift-frontend-libs/compare/9.4.1...9.4.2
 [9.4.1]: https://github.com/infinum/eightshift-frontend-libs/compare/9.4.0...9.4.1
 [9.4.0]: https://github.com/infinum/eightshift-frontend-libs/compare/9.3.1...9.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/frontend-libs",
-	"version": "9.4.2",
+	"version": "9.5.0",
 	"description": "A collection of useful frontend utility modules. powered by Eightshift",
 	"author": {
 		"name": "Eightshift team",

--- a/scripts/components/custom-select/docs/readme.mdx
+++ b/scripts/components/custom-select/docs/readme.mdx
@@ -87,7 +87,7 @@ Your IDE will display all the properties, together with their descriptions.
 
 ### Synchronous multiple items
 ```jsx
-<MutliSelect
+<MultiSelect
 	options={things}
 	placeholder={__('Select a single item', 'eigthshift-frontend-libs')}
 	value={myValue}

--- a/scripts/components/link-input/link-input.js
+++ b/scripts/components/link-input/link-input.js
@@ -110,6 +110,10 @@ export const LinkInput = ({
 		}
 
 		const fetchSuggestionData = async () => {
+			if (document?.activeElement !== inputRef?.current) {
+				return;
+			}
+
 			if (!suggestionsVisible) {
 				setSuggestionFocusMessageVisible(true);
 			}
@@ -353,9 +357,8 @@ export const LinkInput = ({
 								<div className='es-m-1.5'>
 									{suggestionFocusMessageVisible &&
 										<IconLabel
-											icon={
 											// eslint-disable-next-line max-len
-											<span className='es-text-align-center es-py-0.25 es-bg-cool-gray-100 es-color-cool-gray-450 es-rounded-1 es-user-select-none es-text-2.75 es-w-6'>Tab</span>}
+											icon={<span className='es-text-align-center es-py-0.25 es-bg-cool-gray-100 es-color-cool-gray-450 es-rounded-1 es-user-select-none es-text-2.75 es-w-6'>Tab</span>}
 											label={__('Focus on suggestions', 'eightshift-frontend-libs')}
 											additionalClasses='es-mb-1'
 											standalone

--- a/scripts/editor/registration.js
+++ b/scripts/editor/registration.js
@@ -893,6 +893,9 @@ export const registerBlock = (
 
 				return customName;
 			},
+			supports: {
+				__experimentalMetadata: true,
+			},
 		},
 	};
 };


### PR DESCRIPTION
### Updated
- Fixed block renaming (due to recent Gutenberg changes)
- `LinkInput` should now pop the suggestion panel only when focused into the input field
- Fixed typo in `MultiSelect` story

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with block renaming due to recent updates.
	- Adjusted `LinkInput` component behavior to improve usability by showing suggestions only when focused.
	- Corrected typos related to the `MultiSelect` component documentation and naming.

- **New Features**
	- Added support for experimental metadata in block registration, enhancing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->