### PR TITLE
Standardize Accessibility of Quote Blocks Across Browsers

### DIFF
--- a/blocks/init/src/Blocks/components/quote/quote.php
+++ b/blocks/init/src/Blocks/components/quote/quote.php
@@ -36,7 +36,7 @@ $quoteCaptionClass = Components::selector($componentClass, $componentClass, 'cap
 $quoteAuthorUse = Components::checkAttr('quoteAuthorUse', $attributes, $manifest);
 ?>
 
-<figure class="<?php echo esc_attr($quoteClass); ?>" role="figure" aria-describedby="caption-<?php echo esc_attr($unique); ?>">
+<figure class="<?php echo esc_attr($quoteClass); ?>" role="presentation" aria-describedby="caption-<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::render('icon', Components::props('icon', $attributes, [
 		'blockClass' => $componentClass

--- a/blocks/init/src/Blocks/components/quote/quote.php
+++ b/blocks/init/src/Blocks/components/quote/quote.php
@@ -16,6 +16,8 @@ if (!$quoteUse) {
 	return;
 }
 
+$unique = Components::getUnique();
+
 $componentClass = $manifest['componentClass'] ?? '';
 $additionalClass = $attributes['additionalClass'] ?? '';
 $blockClass = $attributes['blockClass'] ?? '';
@@ -34,7 +36,7 @@ $quoteCaptionClass = Components::selector($componentClass, $componentClass, 'cap
 $quoteAuthorUse = Components::checkAttr('quoteAuthorUse', $attributes, $manifest);
 ?>
 
-<figure class="<?php echo esc_attr($quoteClass); ?>">
+<figure class="<?php echo esc_attr($quoteClass); ?>" role="figure" aria-describedby="caption-<?php echo esc_attr($unique); ?>">
 	<?php
 	echo Components::render('icon', Components::props('icon', $attributes, [
 		'blockClass' => $componentClass
@@ -52,7 +54,7 @@ $quoteAuthorUse = Components::checkAttr('quoteAuthorUse', $attributes, $manifest
 	<?php if ($quoteAuthorUse) { ?>
 		<div class="<?php echo esc_attr($quoteSeparatorClass); ?>"></div>
 
-		<figcaption class="<?php echo esc_attr($quoteCaptionClass); ?>">
+		<figcaption class="<?php echo esc_attr($quoteCaptionClass); ?>" id="caption-<?php echo esc_attr($unique); ?>">
 			<?php
 			echo Components::render('paragraph', Components::props('author', $attributes, [
 				'blockClass' => $componentClass

--- a/blocks/init/src/Blocks/components/quote/quote.php
+++ b/blocks/init/src/Blocks/components/quote/quote.php
@@ -16,8 +16,6 @@ if (!$quoteUse) {
 	return;
 }
 
-$unique = Components::getUnique();
-
 $componentClass = $manifest['componentClass'] ?? '';
 $additionalClass = $attributes['additionalClass'] ?? '';
 $blockClass = $attributes['blockClass'] ?? '';
@@ -36,7 +34,7 @@ $quoteCaptionClass = Components::selector($componentClass, $componentClass, 'cap
 $quoteAuthorUse = Components::checkAttr('quoteAuthorUse', $attributes, $manifest);
 ?>
 
-<figure class="<?php echo esc_attr($quoteClass); ?>" role="presentation" aria-describedby="caption-<?php echo esc_attr($unique); ?>">
+<figure class="<?php echo esc_attr($quoteClass); ?>" role="presentation">
 	<?php
 	echo Components::render('icon', Components::props('icon', $attributes, [
 		'blockClass' => $componentClass
@@ -54,7 +52,7 @@ $quoteAuthorUse = Components::checkAttr('quoteAuthorUse', $attributes, $manifest
 	<?php if ($quoteAuthorUse) { ?>
 		<div class="<?php echo esc_attr($quoteSeparatorClass); ?>"></div>
 
-		<figcaption class="<?php echo esc_attr($quoteCaptionClass); ?>" id="caption-<?php echo esc_attr($unique); ?>">
+		<figcaption class="<?php echo esc_attr($quoteCaptionClass); ?>" role="presentation">
 			<?php
 			echo Components::render('paragraph', Components::props('author', $attributes, [
 				'blockClass' => $componentClass


### PR DESCRIPTION
# Description

Each element within the quote block is read individually.

# Screenshots / Videos


https://github.com/infinum/eightshift-frontend-libs/assets/97440314/2234e838-44e9-49f0-88af-870bbb46400c


https://github.com/infinum/eightshift-frontend-libs/assets/97440314/1260c1d9-98dc-4cbb-81af-c4f8251edd89


# Linked documentation PR

https://app.productive.io/1-infinum/tasks/7863543
