### PR TITLE
Support an optional `domain` argument in setCookie helper

### DIFF
--- a/scripts/helpers/cookies.js
+++ b/scripts/helpers/cookies.js
@@ -20,16 +20,22 @@ export const cookies = {
 	 * cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/');
 	 * ```
 	 */
-	setCookie(key, value, time, path) {
+	setCookie(key, value, time, path, domain) {
 		const expires = new Date();
 		expires.setTime(expires.getTime() + (time));
+		
 		let pathValue = '';
+		let domainValue = '';
 
 		if (typeof path !== 'undefined') {
-			pathValue = `path=${path};`;
+			pathValue = `;path=${path}`;
 		}
 
-		document.cookie = `${key}=${value};${pathValue}expires=${expires.toUTCString()}`;
+		if (typeof domain !== 'undefined') {
+			domainValue = `;domain=${domain}`;
+		}
+
+		document.cookie = `${key}=${value}${pathValue}${domainValue};expires=${expires.toUTCString()}`;
 	},
 
 	/**


### PR DESCRIPTION
Adds an optional `domain` argument to the setCookie helper so the cookie domain can be set.

Additionally, does a minor restructuring of how the `document.cookie` value is generated.