### PR TITLE
Add Secure and SameSite parameters as options to cookie method

### DIFF
--- a/scripts/helpers/cookies.js
+++ b/scripts/helpers/cookies.js
@@ -23,7 +23,7 @@ export const cookies = {
 	 * cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/', '.example.com', true, 'Strict');
 	 * ```
 	 */
-	setCookie(key, value, time, path, domain, secure = false, sameSite = 'Lax') {
+	setCookie(key, value, time, path, domain, secure = true, sameSite = 'Lax') {
 		const expires = new Date();
 		expires.setTime(expires.getTime() + (time));
 
@@ -41,11 +41,14 @@ export const cookies = {
 		const cookieParts = [
 			`${key}=${value}`,
 			`expires=${expires.toUTCString()}`,
-			`secure=${secure}`,
 			`SameSite=${sameSite}`,
 			pathValue,
 			domainValue,
 		];
+
+		if (secure) {
+			cookieParts.push('Secure');
+		}
 
 		try {
 			document.cookie = cookieParts.join('; ');

--- a/scripts/helpers/cookies.js
+++ b/scripts/helpers/cookies.js
@@ -25,37 +25,25 @@ export const cookies = {
 	 */
 	setCookie(key, value, time, path, domain, secure = true, sameSite = 'Lax') {
 		const expires = new Date();
-		expires.setTime(expires.getTime() + (time));
+		expires.setTime(expires.getTime() + time);
 
-		let pathValue = '';
-		let domainValue = '';
-
-		if (typeof path !== 'undefined') {
-			pathValue = `;path=${path}`;
-		}
-
-		if (typeof domain !== 'undefined') {
-			domainValue = `;domain=${domain}`;
-		}
-
-		const cookieParts = [
-			`${key}=${value}`,
-			`expires=${expires.toUTCString()}`,
-			`SameSite=${sameSite}`,
-			pathValue,
-			domainValue,
-		];
-
-		if (secure) {
-			cookieParts.push('Secure');
-		}
+		const cookieParts = {
+			value: `${key}=${value}`,
+			expires: `expires=${expires.toUTCString()}`,
+			sameSite: `SameSite=${sameSite}`,
+			path: path ? `path=${path}` : '',
+			domain: domain ? `domain=${domain}` : '',
+			secure: secure ? 'Secure' : '',
+		};
 
 		try {
-			document.cookie = cookieParts.join('; ');
+			document.cookie = Object.values(cookieParts)
+			.filter(Boolean)
+			.join('; ');
 
 			return true;
 		} catch (e) {
-			console.error("Failed to set cookie:", e);
+			console.error('Failed to set cookie:', e);
 
 			return false;
 		}

--- a/scripts/helpers/cookies.js
+++ b/scripts/helpers/cookies.js
@@ -20,7 +20,7 @@ export const cookies = {
 	 *
 	 * Usage:
 	 * ```js
-	 * cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/');
+	 * cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/', '.example.com', true, 'Strict');
 	 * ```
 	 */
 	setCookie(key, value, time, path, domain, secure = false, sameSite = 'Lax') {

--- a/scripts/helpers/cookies.js
+++ b/scripts/helpers/cookies.js
@@ -10,20 +10,23 @@ export const cookies = {
 	 * @param {string} value - Cookie value.
 	 * @param {number} time  - Number denoting the expiration of the cookie.
 	 * @param {string} path  - URL path that must exist in the requested URL in order to send the Cookie header.
+	 * @param {string} domain  - Domain name of the server that set the cookie.
+	 * @param {boolean} secure - A secure cookie is only sent to the server with an encrypted request over the HTTPS protocol.
+	 * @param {string} sameSite - A SameSite cookie prevents the browser from sending this cookie along with cross-site requests
 	 *
 	 * @access public
 	 *
-	 * @returns {void}
+	 * @returns {boolean}
 	 *
 	 * Usage:
 	 * ```js
 	 * cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/');
 	 * ```
 	 */
-	setCookie(key, value, time, path, domain) {
+	setCookie(key, value, time, path, domain, secure = false, sameSite = 'Lax') {
 		const expires = new Date();
 		expires.setTime(expires.getTime() + (time));
-		
+
 		let pathValue = '';
 		let domainValue = '';
 
@@ -35,7 +38,24 @@ export const cookies = {
 			domainValue = `;domain=${domain}`;
 		}
 
-		document.cookie = `${key}=${value}${pathValue}${domainValue};expires=${expires.toUTCString()}`;
+		const cookieParts = [
+			`${key}=${value}`,
+			`expires=${expires.toUTCString()}`,
+			`secure=${secure}`,
+			`SameSite=${sameSite}`,
+			pathValue,
+			domainValue,
+		];
+
+		try {
+			document.cookie = cookieParts.join('; ');
+
+			return true;
+		} catch (e) {
+			console.error("Failed to set cookie:", e);
+
+			return false;
+		}
 	},
 
 	/**


### PR DESCRIPTION
# Description

We started getting errors from BugSnag for unsecured cookies, so I solved this on a project, but consider we should also have this as an option in FE Libs cookie helper.

This will set `sameSite` default to `Lax` (which is already default, but not in all browsers, like Safari or Firefox). Means that cookie is not sent on cross-site requests by default. More [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#lax).

Also, set `Secure` attribute by default, which indicates that the cookie is sent to the server only when a request is made with the https: scheme (except on localhost), and therefore, is more resistant to [man-in-the-middle](https://developer.mozilla.org/en-US/docs/Glossary/MitM) attacks. 