### PR TITLE
Adding supports to block registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [13.0.9]
+
+### Added
+
+- `supports` key to the blocks registration process.
+
 ## [13.0.8]
 
 ### Changed
@@ -1392,6 +1398,7 @@ Follow this migration script in order for you project to work correctly with the
 - Initial tagged release.
 
 [Unreleased]: https://github.com/infinum/eightshift-frontend-libs/compare/master...HEAD
+[13.0.9]: https://github.com/infinum/eightshift-frontend-libs/compare/13.0.8...13.0.9
 [13.0.8]: https://github.com/infinum/eightshift-frontend-libs/compare/13.0.7...13.0.8
 [13.0.7]: https://github.com/infinum/eightshift-frontend-libs/compare/13.0.6...13.0.7
 [13.0.6]: https://github.com/infinum/eightshift-frontend-libs/compare/13.0.5...13.0.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/frontend-libs",
-	"version": "13.0.8",
+	"version": "13.0.9",
 	"description": "A collection of useful frontend utility modules. powered by Eightshift",
 	"author": {
 		"name": "Eightshift team",

--- a/scripts/editor/registration.js
+++ b/scripts/editor/registration.js
@@ -862,6 +862,11 @@ export const registerBlock = (
 		...getExample('', blockManifest),
 	};
 
+	// Block supports.
+	if (typeof blockManifest['supports'] === 'undefined') {
+		blockManifest['supports'] = {};
+	}
+
 	return {
 		blockName: fullBlockName,
 		options: {
@@ -889,6 +894,7 @@ export const registerBlock = (
 				return customName;
 			},
 			supports: {
+				...blockManifest['supports'],
 				__experimentalMetadata: true,
 			},
 		},


### PR DESCRIPTION
### Added

- `supports` key to the blocks registration process.