### PR TITLE
Remove useRemBaseSize and update CSS output defaults

### DIFF
--- a/schemas/globalManifest.json
+++ b/schemas/globalManifest.json
@@ -45,10 +45,6 @@
 					"type": "array",
 					"description": "With this key you append CSS variables to the final inline output style tag. You can use this key to provide loading state for example. Default: []."
 				},
-				"useRemBaseSize": {
-					"type": "boolean",
-					"description": "If true, all CSS variables outputted inside the editor will have REMs converted to calced values. Default: false"
-				},
 				"useWrapper": {
 					"type": "boolean",
 					"description": "With this key you can change if you want to use Wrapper in your project. Default: true"
@@ -97,12 +93,7 @@
 							"description": "Breakpoint value for large size."
 						}
 					},
-					"required": [
-						"mobile",
-						"tablet",
-						"desktop",
-						"large"
-					]
+					"required": ["mobile", "tablet", "desktop", "large"]
 				},
 				"containers": {
 					"type": "object",
@@ -129,11 +120,7 @@
 							"description": "Section spacing step interval."
 						}
 					},
-					"required": [
-						"min",
-						"max",
-						"step"
-					]
+					"required": ["min", "max", "step"]
 				},
 				"sectionInSpacing": {
 					"type": "object",
@@ -152,11 +139,7 @@
 							"description": "Section spacing step interval."
 						}
 					},
-					"required": [
-						"min",
-						"max",
-						"step"
-					]
+					"required": ["min", "max", "step"]
 				},
 				"colors": {
 					"type": "array",
@@ -181,18 +164,8 @@
 					}
 				}
 			},
-			"required": [
-				"customBlocksName",
-				"maxCols",
-				"breakpoints",
-				"colors"
-			]
+			"required": ["customBlocksName", "maxCols", "breakpoints", "colors"]
 		}
 	},
-	"required": [
-		"namespace",
-		"background",
-		"foreground",
-		"globalVariables"
-	]
+	"required": ["namespace", "background", "foreground", "globalVariables"]
 }

--- a/scripts/editor/store.js
+++ b/scripts/editor/store.js
@@ -9,11 +9,10 @@ const DEFAULT_STATE = {
 	blocks: {},
 	components: {},
 	config: {
-		outputCssGlobally: false,
-		outputCssOptimize: false,
+		outputCssGlobally: true,
+		outputCssOptimize: true,
 		outputCssSelectorName: 'esCssVariables',
 		outputCssGloballyAdditionalStyles: [],
-		useRemBaseSize: false,
 		useWrapper: true,
 	},
 	wrapper: {},
@@ -57,9 +56,6 @@ const selectors = {
 	},
 	getConfigOutputCssGloballyAdditionalStyles(state) {
 		return state.config.outputCssGloballyAdditionalStyles;
-	},
-	getConfigUseRemBaseSize(state) {
-		return state.config.useRemBaseSize;
 	},
 	getConfigUseWrapper(state) {
 		return state.config.useWrapper;
@@ -119,12 +115,6 @@ const actions = {
 	setConfigOutputCssOptimize(config) {
 		return {
 			type: 'SET_CONFIG_OUTPUT_CSS_OPTIMIZE',
-			config,
-		};
-	},
-	setConfigUseRemBaseSize(config) {
-		return {
-			type: 'SET_CONFIG_USE_REM_BASE_SIZE',
 			config,
 		};
 	},
@@ -240,15 +230,6 @@ const reducer = (state = DEFAULT_STATE, action) => {
 				config: {
 					...state.config,
 					outputCssSelectorName: action.config,
-				},
-			};
-		}
-		case 'SET_CONFIG_USE_REM_BASE_SIZE': {
-			return {
-				...state,
-				config: {
-					...state.config,
-					useRemBaseSize: action.config,
 				},
 			};
 		}
@@ -371,11 +352,6 @@ export const setConfigFlags = () => {
 		// outputCssOptimize
 		if (typeof config?.outputCssOptimize === 'boolean') {
 			dispatch(STORE_NAME).setConfigOutputCssOptimize(config.outputCssOptimize);
-		}
-
-		// useRemBaseSize
-		if (typeof config?.useRemBaseSize === 'boolean') {
-			dispatch(STORE_NAME).setConfigUseRemBaseSize(config.useRemBaseSize);
 		}
 
 		// outputCssSelectorName


### PR DESCRIPTION
# Description

### Removed

- Removed `useRemBaseSize` config option from the editor store (default state, selector, action, reducer, and `setConfigFlags`)
- Removed `useRemBaseSize` property from `globalManifest.json` schema

### Changed

- Updated `outputCssGlobally` default from `false` to `true`
- Updated `outputCssOptimize` default from `false` to `true`

## QA Guide

Steps for QA to test this feature:
1. Open a project using eightshift-frontend-libs and verify CSS variables are output globally by default (without setting `outputCssGlobally: true` in global manifest)
2. Verify CSS output optimization is enabled by default
3. Confirm removing any `useRemBaseSize` setting from existing global manifests causes no errors

**Expected result:** CSS variables are output globally and optimized by default. No errors related to `useRemBaseSize` being undefined.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Productive ticket

N/A